### PR TITLE
feat: 마이그레이션 CI/CD 반영 + bible seed 추가

### DIFF
--- a/.github/workflows/supabase-deploy-prod.yaml
+++ b/.github/workflows/supabase-deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Supabase Function Deploy Prod
+name: Supabase Deploy Prod
 
 on:
   release:
@@ -18,5 +18,11 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: 2.109.1
+
+      # 마이그레이션을 함수 배포보다 먼저 적용한다 (새 함수가 새 스키마에 의존할 수 있음).
+      # pending 마이그레이션이 없으면 no-op. prod 반영은 release 발행이 수동 게이트다.
+      - run: supabase link --project-ref $PROJECT_ID
+
+      - run: supabase db push --yes
 
       - run: supabase functions deploy --project-ref $PROJECT_ID

--- a/.github/workflows/supabase-deploy-staging.yaml
+++ b/.github/workflows/supabase-deploy-staging.yaml
@@ -1,4 +1,4 @@
-name: Supabase Function Deploy Staging
+name: Supabase Deploy Staging
 
 on:
   push:
@@ -19,5 +19,11 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: 2.109.1
+
+      # 마이그레이션을 함수 배포보다 먼저 적용한다 (새 함수가 새 스키마에 의존할 수 있음).
+      # pending 마이그레이션이 없으면 no-op 이라 매 배포마다 돌아도 안전하다.
+      - run: supabase link --project-ref $PROJECT_ID
+
+      - run: supabase db push --yes
 
       - run: supabase functions deploy --project-ref $PROJECT_ID

--- a/.github/workflows/supabase-migration-check.yaml
+++ b/.github/workflows/supabase-migration-check.yaml
@@ -1,0 +1,25 @@
+name: Supabase Migration Check
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/seed.sql"
+      - "supabase/config.toml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.109.1
+
+      # 로컬 Postgres 를 띄워 마이그레이션 전체 + 시드를 처음부터 재생한다.
+      # 여기서 실패하면 staging/prod 배포에서도 실패한다 — merge 전에 잡는다.
+      - run: supabase db start
+
+      - run: supabase db reset --local


### PR DESCRIPTION
## 배경
마이그레이션 반영을 로컬에서 링크 전환하며 `db push` 하는 방식은 사람 실수에 취약합니다. 마이그레이션 체계 도입(#27)의 최종 목적지인 **CI/CD 기반 반영**으로 전환합니다.

## 변경 사항

### 배포 워크플로우에 `db push` 통합
- **staging** (main push 트리거) / **prod** (release 발행 트리거) 모두: `link → db push --yes → functions deploy` 순서
- 마이그레이션을 함수 배포보다 **먼저** 적용 — 새 함수가 새 스키마에 의존하는 경우의 순서 보장
- pending 마이그레이션이 없으면 no-op (멱등) — 매 배포마다 돌아도 안전
- 시크릿은 기존 `SUPABASE_ACCESS_TOKEN` / `SUPABASE_PROJECT_ID_*` 그대로, 추가 시크릿 불필요

### PR 검증 워크플로우 신설 (`supabase-migration-check.yaml`)
- `supabase/migrations/**`·seed·config 변경 PR에서 로컬 Postgres로 **전체 마이그레이션+시드 재생** — 깨진 마이그레이션이 main에 들어가는 걸 merge 전에 차단

### bible 참조 데이터 시드
- `supabase/seed.sql`: prod 기준 성경 본문 31,138행 (6MB) — 로컬 `db reset` 시 말씀카드 기능 동작에 필수

## 이후 스키마 변경 흐름
```
supabase migration new <name> → 로컬 db reset 검증 → PR (migration-check 자동 검증)
→ merge 시 staging 자동 반영 → release 발행 시 prod 자동 반영
```
로컬에서 원격으로 직접 push하는 일은 더 이상 없습니다.

## 검증
- 이 PR 자체가 migration-check 워크플로우의 첫 실행 대상 (seed.sql 변경 포함)
- merge 시 staging 배포에서 `db push`가 no-op으로 통과하는지 확인 (staging은 이미 최신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)