### PR TITLE
fix: bible 테이블의 무제한 쓰기 RLS 정책 제거

### DIFF
--- a/supabase/migrations/20260724115632_drop_bible_write_policies.sql
+++ b/supabase/migrations/20260724115632_drop_bible_write_policies.sql
@@ -1,0 +1,7 @@
+-- bible 은 불변 참조 데이터(성경 본문) — 클라이언트 쓰기 정책이 존재할 이유가 없다.
+-- prod 유래의 무제한 쓰기 정책 2건 제거:
+--   "update rls" FOR UPDATE USING (true)      → 역할 미지정이라 anon 포함 누구나 수정 가능했음
+--   "insert rls" FOR INSERT WITH CHECK (true) → 동일하게 누구나 행 추가 가능했음
+-- 읽기("select rls")는 유지. 관리자 데이터 적재는 RLS 를 우회하는 postgres/service_role 로 수행.
+drop policy if exists "update rls" on "public"."bible";
+drop policy if exists "insert rls" on "public"."bible";


### PR DESCRIPTION
## 배경
staging↔prod 드리프트 전수조사에서 발견된 보안 허점 조치입니다. `bible`(성경 본문 — 불변 참조 데이터)에 역할 미지정 무제한 쓰기 정책이 있어 **anon 포함 누구나 REST로 본문 수정·행 추가가 가능**했습니다.

## 변경
- `drop policy "update rls"` — 승인된 건
- `drop policy "insert rls"` — 마이그레이션 작성 중 발견된 동급 허점, 같은 논리로 포함 (**리뷰 시 확인 요청**)
- `select rls`(읽기)는 유지 — 앱의 성경 조회 필수

## 검증 (로컬)
- `db reset` 3개 마이그레이션 무오류 재생
- 정책 잔존: `select rls (SELECT)` 만
- anon 읽기 정상 / anon PATCH → 0행 적용(차단) / 데이터 무손상 확인

## 반영 경로
merge → staging 자동 적용, prod는 다음 release 발행 시. 나머지 RLS 전면 정비는 별도 보안 백로그 문서로 관리 (PrayU-Web docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)