### PR TITLE
chore: 함수 DB 접속을 런타임 자동 주입 env로 전환 (로컬이 staging을 쓰던 문제 해소)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 .branches
 .temp
 
-# env
+# env (.env.local은 로컬 데모값이라 커밋 대상)
 .env
+.env.serve
 
 # node_modules
 node_modules

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,2 +1,5 @@
 supabase start
+
+# DB 접속 정보(SUPABASE_URL 등)는 런타임이 자동 주입 (로컬 serve → 로컬 스택)
+# .env는 OpenAI 등 서드파티 시크릿 전달용
 supabase functions serve --env-file ./.env --no-verify-jwt

--- a/supabase/functions/_shared/authMiddleware.ts
+++ b/supabase/functions/_shared/authMiddleware.ts
@@ -25,7 +25,7 @@ export async function authMiddleware(c: Context, next: Next) {
   const jwt = authHeader.split(" ")[1];
   console.log("Processing request with JWT token");
 
-  if (jwt === Deno.env.get("SUPA_PROJECT_SERVICE_ROLE_KEY")) {
+  if (jwt === Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")) {
     c.set("userId", "service_role");
     await next();
     return;

--- a/supabase/functions/client.ts
+++ b/supabase/functions/client.ts
@@ -1,7 +1,9 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.44.3";
 import { Database } from "./_types/database.ts";
 
+// SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY는 런타임이 자동 주입한다
+// (로컬 serve → 로컬 스택, 배포 → 해당 프로젝트). 별도 시크릿 설정 불필요
 export const supabase = createClient<Database>(
-  Deno.env.get("SUPA_PROJECT_URL")!,
-  Deno.env.get("SUPA_PROJECT_SERVICE_ROLE_KEY")!,
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
 );


### PR DESCRIPTION
## 문제
`scripts/dev.sh`가 `.env`(스테이징 시크릿)를 그대로 함수에 넘겨, **로컬에서 함수를 띄우면 staging DB에 service role로 실제 읽기/쓰기**가 나갔습니다. 워크스페이스 철칙("원격은 CI 전용") 위반 상태였고 PR #33 검증 중 발견했습니다.

## 해결 — 커스텀 시크릿 제거, 런타임 자동 주입 env 사용
Supabase 함수 런타임은 `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`를 **자동 주입**합니다 (로컬 serve → 로컬 스택, 배포 → 해당 프로젝트). 커스텀 `SUPA_PROJECT_*`를 쓸 이유가 없었습니다.

- `functions/client.ts`: `SUPA_PROJECT_URL/KEY` → `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`
- `functions/_shared/authMiddleware.ts`: service role 비교도 동일 전환 (배포 환경에선 같은 값 — 동작 변화 없음)
- `scripts/dev.sh`: 주석만 정리 (`.env`는 OpenAI 등 서드파티 시크릿 전달용으로 유지)

## 검증 (로컬)
- `./scripts/dev.sh` 기동 → 사용자 토큰으로 bible 호출 → 200 + 로컬 bible 테이블 구절 반환 (자동 주입 값으로 로컬 DB 접근 증명)
- 무인증 호출 401 (미들웨어 정상)

## 후속 정리 (merge 후, 별도)
- `.env`의 `SUPA_PROJECT_URL`/`SUPA_PROJECT_SERVICE_ROLE_KEY` 2줄 제거 가능 (미사용)
- staging/prod 대시보드의 동명 function secrets 제거 가능 (미사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
