### PR TITLE
feat: 카카오톡 공유 보상 — 웹훅 수신 및 말씀카드 동적 한도

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -221,3 +221,8 @@ verify_jwt = true
 
 [functions.openai]
 verify_jwt = true
+
+# 카카오 웹훅: 카카오 서버는 JWT를 보내지 않으므로 게이트웨이 검증 제외.
+# 함수 내부의 KakaoAK 어드민 키 대조가 유일한 방어선이다 (kakao-webhook/index.ts 참조)
+[functions.kakao-webhook]
+verify_jwt = false

--- a/supabase/functions/_shared/kst.ts
+++ b/supabase/functions/_shared/kst.ts
@@ -1,0 +1,11 @@
+// KST 기준 오늘 0시를 UTC ISO 문자열로 반환 (프로젝트 날짜 기준은 KST)
+export function kstDayStartISO(): string {
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const kstNow = new Date(Date.now() + KST_OFFSET_MS);
+  const kstDayStartMs = Date.UTC(
+    kstNow.getUTCFullYear(),
+    kstNow.getUTCMonth(),
+    kstNow.getUTCDate(),
+  ) - KST_OFFSET_MS;
+  return new Date(kstDayStartMs).toISOString();
+}

--- a/supabase/functions/_shared/llmUsageRepository.ts
+++ b/supabase/functions/_shared/llmUsageRepository.ts
@@ -1,27 +1,16 @@
 import { supabase } from "../client.ts";
 import { AIUsage } from "./ai/aiClient.ts";
 import { Json } from "../_types/database.ts";
+import { kstDayStartISO } from "./kst.ts";
 
 export class LlmUsageRepository {
-  // KST 기준 오늘 0시를 UTC ISO 문자열로 반환 (프로젝트 날짜 기준은 KST)
-  private kstDayStartISO(): string {
-    const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-    const kstNow = new Date(Date.now() + KST_OFFSET_MS);
-    const kstDayStartMs = Date.UTC(
-      kstNow.getUTCFullYear(),
-      kstNow.getUTCMonth(),
-      kstNow.getUTCDate(),
-    ) - KST_OFFSET_MS;
-    return new Date(kstDayStartMs).toISOString();
-  }
-
   async countToday(userId: string, feature: string): Promise<number> {
     const { count, error } = await supabase
       .from("llm_usage_log")
       .select("id", { count: "exact", head: true })
       .eq("user_id", userId)
       .eq("feature", feature)
-      .gte("created_at", this.kstDayStartISO());
+      .gte("created_at", kstDayStartISO());
 
     if (error) {
       console.error("Error counting llm usage:", error.code, error.message);

--- a/supabase/functions/_shared/shareRewardRepository.ts
+++ b/supabase/functions/_shared/shareRewardRepository.ts
@@ -1,0 +1,59 @@
+import { supabase } from "../client.ts";
+import { kstDayStartISO } from "./kst.ts";
+
+// 공유 보상 로그 접근 — kakao-webhook(쓰기)과 bible(한도 계산용 읽기)이 공유한다
+export class ShareRewardRepository {
+  async countToday(userId: string, feature: string): Promise<number> {
+    const { count, error } = await supabase
+      .from("share_reward_log")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("feature", feature)
+      .gte("created_at", kstDayStartISO());
+
+    if (error) {
+      console.error("Error counting share reward:", error.code, error.message);
+      throw error;
+    }
+    return count ?? 0;
+  }
+
+  async existsTodayInRoom(
+    userId: string,
+    hashChatId: string,
+  ): Promise<boolean> {
+    const { count, error } = await supabase
+      .from("share_reward_log")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("hash_chat_id", hashChatId)
+      .gte("created_at", kstDayStartISO());
+
+    if (error) {
+      console.error("Error checking share reward room:", error.code, error.message);
+      throw error;
+    }
+    return (count ?? 0) > 0;
+  }
+
+  async insert(
+    userId: string,
+    feature: string,
+    chatType: string | null,
+    hashChatId: string | null,
+  ): Promise<void> {
+    const { error } = await supabase
+      .from("share_reward_log")
+      .insert({
+        user_id: userId,
+        feature,
+        chat_type: chatType,
+        hash_chat_id: hashChatId,
+      });
+
+    if (error) {
+      console.error("Error inserting share reward:", error.code, error.message);
+      throw error;
+    }
+  }
+}

--- a/supabase/functions/_types/database.ts
+++ b/supabase/functions/_types/database.ts
@@ -569,6 +569,41 @@ export type Database = {
           },
         ]
       }
+      share_reward_log: {
+        Row: {
+          chat_type: string | null
+          created_at: string
+          feature: string
+          hash_chat_id: string | null
+          id: string
+          user_id: string
+        }
+        Insert: {
+          chat_type?: string | null
+          created_at?: string
+          feature: string
+          hash_chat_id?: string | null
+          id?: string
+          user_id: string
+        }
+        Update: {
+          chat_type?: string | null
+          created_at?: string
+          feature?: string
+          hash_chat_id?: string | null
+          id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "share_reward_log_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       thanks_card: {
         Row: {
           content: string

--- a/supabase/functions/bible/bibleService.ts
+++ b/supabase/functions/bible/bibleService.ts
@@ -8,8 +8,10 @@ import {
 } from "./bibleSchema.ts";
 import { Bible } from "../_types/table.ts";
 import { LlmUsageRepository } from "../_shared/llmUsageRepository.ts";
+import { ShareRewardRepository } from "../_shared/shareRewardRepository.ts";
 
 // 말씀카드 일일 생성 한도 — bible_card 피처의 정책이므로 이 파일에 둔다 (서버가 진실, web 상수는 표시용)
+// 실제 한도 = 기본값 + 당일 공유 보상 수 (docs: PrayU-web/docs/share-reward-plan.md)
 const DAILY_LIMIT = Number(Deno.env.get("BIBLE_CARD_DAILY_LIMIT") ?? "3");
 
 export class DailyLimitExceededError extends Error {
@@ -22,11 +24,13 @@ export class BibleService {
   private aiClient: AIClient;
   private bibleRepository: BibleRepository;
   private llmUsageRepository: LlmUsageRepository;
+  private shareRewardRepository: ShareRewardRepository;
 
   constructor() {
     this.aiClient = new OpenaiClient(Deno.env.get("OPENAI_SECRET_KEY") || "");
     this.bibleRepository = new BibleRepository();
     this.llmUsageRepository = new LlmUsageRepository();
+    this.shareRewardRepository = new ShareRewardRepository();
   }
 
   async searchBible(userId: string, userPrompt: string, prayCardId?: string) {
@@ -62,8 +66,13 @@ export class BibleService {
     `;
 
     const used = await this.llmUsageRepository.countToday(userId, "bible_card");
-    if (used >= DAILY_LIMIT) {
-      throw new DailyLimitExceededError(DAILY_LIMIT, used);
+    const rewards = await this.shareRewardRepository.countToday(
+      userId,
+      "bible_card",
+    );
+    const limit = DAILY_LIMIT + rewards;
+    if (used >= limit) {
+      throw new DailyLimitExceededError(limit, used);
     }
 
     // LLM 호출 "전"에 기록해 실패·타임아웃 호출도 차감 (재시도 폭탄 방지)

--- a/supabase/functions/kakao-webhook/index.ts
+++ b/supabase/functions/kakao-webhook/index.ts
@@ -1,0 +1,14 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { Hono } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { KakaoWebhookController } from "./kakaoWebhookController.ts";
+
+// 카카오톡 공유 웹훅 수신 함수 (docs: PrayU-web/docs/share-reward-plan.md)
+// authMiddleware 미사용 — 호출 주체가 카카오 서버라 JWT가 없고,
+// 컨트롤러의 KakaoAK 어드민 키 대조가 유일한 인증이다 (config.toml verify_jwt=false 필수)
+const app = new Hono();
+const controller = new KakaoWebhookController();
+
+app.get("/kakao-webhook", (c) => controller.handle(c));
+app.post("/kakao-webhook", (c) => controller.handle(c));
+
+Deno.serve(app.fetch);

--- a/supabase/functions/kakao-webhook/kakaoWebhookController.ts
+++ b/supabase/functions/kakao-webhook/kakaoWebhookController.ts
@@ -1,0 +1,61 @@
+import { Context } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { ShareRewardService } from "./shareRewardService.ts";
+
+export class KakaoWebhookController {
+  private shareRewardService: ShareRewardService;
+
+  constructor() {
+    this.shareRewardService = new ShareRewardService();
+  }
+
+  private json(data: unknown, status: number) {
+    return new Response(JSON.stringify(data), {
+      headers: { "Content-Type": "application/json" },
+      status,
+    });
+  }
+
+  async handle(c: Context) {
+    // 카카오 서버 진위 확인 — 대표 어드민 키 대조 (이 함수의 유일한 인증)
+    const adminKey = Deno.env.get("KAKAO_ADMIN_KEY") ?? "";
+    if (!adminKey || c.req.header("Authorization") !== `KakaoAK ${adminKey}`) {
+      console.error("kakao-webhook: invalid KakaoAK authorization");
+      return this.json({ error: "Unauthorized" }, 401);
+    }
+
+    // GET(쿼리) / POST(JSON) 양쪽 지원 (카카오 웹훅 스펙)
+    let params: Record<string, unknown> = {};
+    if (c.req.method === "GET") {
+      params = c.req.query();
+    } else {
+      params = await c.req.json().catch(() => ({}));
+    }
+
+    console.log(
+      "kakao-webhook received:",
+      JSON.stringify({
+        resourceId: c.req.header("X-Kakao-Resource-ID"),
+        chatType: params["CHAT_TYPE"],
+        feature: params["feature"],
+      }),
+    );
+
+    // 3초 내 2XX 응답 요건 — 지급 실패도 200으로 응답하고 사유는 로그로 남긴다
+    // (카카오 재시도 유발 방지: 규칙상 미지급은 우리 쪽 정상 처리)
+    try {
+      const result = await this.shareRewardService.grantReward({
+        userId: String(params["user_id"] ?? ""),
+        feature: String(params["feature"] ?? ""),
+        chatType: params["CHAT_TYPE"] ? String(params["CHAT_TYPE"]) : null,
+        hashChatId: params["HASH_CHAT_ID"] ? String(params["HASH_CHAT_ID"]) : null,
+      });
+      if (!result.granted) {
+        console.log("kakao-webhook: reward not granted -", result.reason);
+      }
+      return this.json({ granted: result.granted }, 200);
+    } catch (error) {
+      console.error("kakao-webhook: grant failed -", error);
+      return this.json({ granted: false }, 200);
+    }
+  }
+}

--- a/supabase/functions/kakao-webhook/shareRewardService.ts
+++ b/supabase/functions/kakao-webhook/shareRewardService.ts
@@ -1,0 +1,54 @@
+import { ShareRewardRepository } from "../_shared/shareRewardRepository.ts";
+
+// 보상 대상 피처 화이트리스트 — 1차는 말씀카드만
+const REWARDABLE_FEATURES = new Set(["bible_card"]);
+
+interface GrantRewardInput {
+  userId: string;
+  feature: string;
+  chatType: string | null;
+  hashChatId: string | null;
+}
+
+export interface GrantRewardResult {
+  granted: boolean;
+  reason?: string;
+}
+
+// 지급 규칙 (docs 2-3장, 2026-07-27 확정):
+// 공유 1회 = +1 (당일 한정, 일일 상한 없음) / 나와의 채팅 미인정 / 동일 채팅방 1일 1회
+export class ShareRewardService {
+  private shareRewardRepository: ShareRewardRepository;
+
+  constructor() {
+    this.shareRewardRepository = new ShareRewardRepository();
+  }
+
+  async grantReward(input: GrantRewardInput): Promise<GrantRewardResult> {
+    const { userId, feature, chatType, hashChatId } = input;
+
+    if (!REWARDABLE_FEATURES.has(feature)) {
+      return { granted: false, reason: `feature not rewardable: ${feature}` };
+    }
+    if (!userId) {
+      return { granted: false, reason: "missing user_id" };
+    }
+    if (chatType === "MemoChat") {
+      return { granted: false, reason: "MemoChat not rewardable" };
+    }
+    if (!hashChatId) {
+      return { granted: false, reason: "missing HASH_CHAT_ID" };
+    }
+
+    const alreadyRewarded = await this.shareRewardRepository.existsTodayInRoom(
+      userId,
+      hashChatId,
+    );
+    if (alreadyRewarded) {
+      return { granted: false, reason: "already rewarded in this room today" };
+    }
+
+    await this.shareRewardRepository.insert(userId, feature, chatType, hashChatId);
+    return { granted: true };
+  }
+}

--- a/supabase/migrations/20260727023732_add_share_reward_log.sql
+++ b/supabase/migrations/20260727023732_add_share_reward_log.sql
@@ -1,0 +1,28 @@
+-- 카카오톡 공유 보상 로그 (docs: PrayU-web/docs/share-reward-plan.md)
+-- 공유 성공 웹훅(kakao-webhook 함수)이 기록하고, bible 함수가 당일 보상 수를 읽어
+-- 말씀카드 생성 한도를 동적으로 올린다 (limit = 기본 3 + 오늘 보상 수)
+create table "public"."share_reward_log" (
+    "id" uuid primary key default gen_random_uuid(),
+    "user_id" uuid not null references "public"."profiles"(id),
+    "feature" text not null,
+    "chat_type" text,
+    "hash_chat_id" text,
+    "created_at" timestamp with time zone not null default now()
+);
+
+-- 한도 계산용 (user_id + feature + 당일)
+create index "idx_share_reward_user_feature"
+    on "public"."share_reward_log" ("user_id", "feature", "created_at" desc);
+-- 동일 채팅방 당일 중복 검사용
+create index "idx_share_reward_user_room"
+    on "public"."share_reward_log" ("user_id", "hash_chat_id", "created_at" desc);
+
+alter table "public"."share_reward_log" enable row level security;
+
+-- 클라이언트는 자기 보상 조회만 가능 (남은 횟수 표시용).
+-- 쓰기 정책은 의도적으로 없음: insert는 kakao-webhook 함수(service role, RLS 우회) 전용
+create policy "select own share reward"
+    on "public"."share_reward_log"
+    for select
+    to authenticated
+    using (auth.uid() = user_id);


### PR DESCRIPTION
## 배경
카카오톡 공유 성공 시 말씀카드 생성 카운트를 지급하는 기획의 서버 측 구현.
계획 문서: PrayU-web `docs/share-reward-plan.md` (파일 매니페스트 A1~A10 — web 짝 PR에 동봉)

## 작업 내용
- **`share_reward_log` 테이블** (마이그레이션): 보상 기록 + 한도/중복 검사용 인덱스 2개. RLS 본인 select만, 쓰기는 함수 전용
- **`kakao-webhook` 함수 (신규)**: 카카오 공유 웹훅 수신
  - 인증: `Authorization: KakaoAK {어드민 키}` 대조 (JWT 아님 → `config.toml verify_jwt=false` 명시)
  - GET/POST 양쪽 파싱, 3초 요건 준수 — 미지급 사유도 200 응답 + 로그 (카카오 재시도 방지)
  - 지급 규칙(2026-07-27 확정): 공유 1회 = +1, **일일 상한 없음**, MemoChat 미인정, **동일 채팅방 1일 1회**
- **`functions/bible` 동적 한도**: `limit = BIBLE_CARD_DAILY_LIMIT(3) + 당일 보상 수`
- `_shared/kst.ts` 공용 승격 (llmUsage·shareReward 저장소 공유), `_shared/shareRewardRepository.ts` 신규

## 검증 (로컬 e2e)
- 웹훅: 잘못된 키 401 / MemoChat 거부 / room-A 지급 / room-A 재공유 거부 / GET·room-B 지급(상한 없음 확인)
- 동적 한도: 보상 2건 + 사용 5건 → **429 `{limit:5, used:5}`** (기본 3+보상 2 정확)
- `supabase db reset` 재생 무오류, `deno check` 통과, 타입 재생성

## merge 후 사람 작업 (계획 문서 4장)
- [ ] 카카오 디벨로퍼스(staging 앱) 웹훅 URL 등록: `https://cguxpeghdqcqfdhvkmyv.supabase.co/functions/v1/kakao-webhook`
- [ ] prod 앱은 Api release 후 등록: `https://qggewtakkrwcclyxtxnz.supabase.co/functions/v1/kakao-webhook`
- [ ] 각 환경 함수 시크릿 `KAKAO_ADMIN_KEY`가 해당 카카오 앱 어드민 키인지 확인
- [ ] 운영 설정 대장(`supabase-migration-plan.md`)에 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)
