### PR TITLE
refactor: 사용 로그 읽기 개방 (어드민 전용 정책 대신)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,7 +16,8 @@
 계획: [PrayU-web/docs/admin-revamp-plan.md](../../PrayU-web/docs/admin-revamp-plan.md) (4개 PR, merge는 **Api 먼저 → web**)
 
 - [x] **PR A** `profiles.is_admin` + `notice` 테이블 + RLS — [#39](https://github.com/TeamVisioneer/PrayU-Api/pull/39) 리뷰 대기
-- [ ] **PR C** `admin` edge function — Hono 라우팅 + `requireAdmin`, 집계는 TS(RPC 미사용), `config.toml`에 `verify_jwt = true`
+- [x] ~~**PR C** `admin` edge function~~ — **폐기**. 대시보드가 읽을 테이블(`profiles`/`group`/`member`/`pray`/`pray_card`)이 이미 `select using(true)`라 함수를 세워도 실질 보호가 0이고 배포 대상만 늘어난다. 대신 사용 로그 읽기만 개방 → [#40](https://github.com/TeamVisioneer/PrayU-Api/pull/40)
+- [ ] **RLS 전면 정비 시 재검토** — security-backlog 1번으로 `group`/`member`/`pray`/`pray_card`가 잠기면 web 대시보드의 클라이언트 조회가 깨진다. 그때 관리자 select 정책 추가 또는 서버 경유로 전환 판단
 
 ## 다음 작업
 

--- a/supabase/migrations/20260727084538_open_usage_log_read.sql
+++ b/supabase/migrations/20260727084538_open_usage_log_read.sql
@@ -1,0 +1,26 @@
+-- 사용 로그 읽기 개방 (docs: PrayU-web/docs/admin-revamp-plan.md)
+--
+-- 어드민 대시보드가 LLM 비용·공유 보상을 집계하려면 전체 로그를 읽어야 한다.
+-- 관리자 전용 select 정책을 따로 두는 대신 읽기를 열었다:
+--   - 저장되는 값은 사용 메타데이터뿐이다 (user_id, feature, model, 토큰 수, 시각,
+--     metadata는 {pray_card_id} 또는 {}). 기도 내용은 들어가지 않는다
+--   - 정작 기도 내용을 담은 pray_card가 이미 select using(true)라, 이 두 테이블만
+--     가려서 얻는 실익이 없다
+-- 접근 모델 전반은 security-backlog 1번(RLS 전면 정비)에서 일괄 재설계한다.
+--
+-- ⚠️ 이 변경으로 "RLS가 본인 것만 준다"는 전제가 사라진다.
+--    사용량을 세는 쪽은 user_id 필터를 명시해야 한다 (web 짝 PR에서 반영).
+drop policy if exists "select own llm usage" on "public"."llm_usage_log";
+drop policy if exists "select own share reward" on "public"."share_reward_log";
+
+create policy "select llm usage"
+    on "public"."llm_usage_log"
+    for select
+    to authenticated
+    using (true);
+
+create policy "select share reward"
+    on "public"."share_reward_log"
+    for select
+    to authenticated
+    using (true);


### PR DESCRIPTION
어드민 대시보드(web PR D) 준비 작업. **짝 PR 필수** — 아래 회귀 주의.

## 배경

어드민 대시보드에서 LLM 비용·공유 보상을 집계하려면 전체 로그를 읽어야 합니다. 처음에는 `admin` edge function을 만들려 했으나 **지금 구조에서는 이득이 없어 접었습니다**: 대시보드가 볼 `profiles`/`group`/`member`/`pray`/`pray_card`는 이미 `select using(true)`라 아무 로그인 사용자나 브라우저에서 그대로 읽습니다. 함수를 세워도 실질 보호가 0인데 배포 대상과 데이터 경로만 늘어납니다.

남은 건 self-only인 두 로그 테이블뿐이라, 관리자 전용 select 정책 대신 **읽기를 열었습니다**:

- 저장값은 사용 메타데이터뿐입니다 (`user_id`, `feature`, `model`, 토큰 수, 시각, `metadata`는 `{pray_card_id}` 또는 `{}`) — 기도 내용은 들어가지 않습니다
- 정작 기도 내용을 담은 `pray_card`가 이미 전면 공개라, 이 두 테이블만 가려서 얻는 실익이 없습니다
- 접근 모델 전반은 security-backlog 1번(RLS 전면 정비)에서 일괄 재설계합니다

알아두실 점: `share_reward_log.hash_chat_id`는 같은 카톡방이면 같은 해시라, 열면 "누가 누구와 같은 방에 있는지" 추론이 가능해집니다. `member`(그룹 소속)가 이미 전면 공개라 결이 크게 다르진 않습니다.

## ⚠️ 회귀 주의 — 짝 PR 없이 merge하면 안 됩니다

web의 `fetchTodayLlmUsage`/`fetchTodayShareReward`는 `user_id` 필터 없이 **RLS가 본인 것만 준다는 데 의존**하고 있었습니다. 이 PR만 반영하면 전체 사용자 집계가 잡혀 **모든 사용자에게 "남은 생성 0회"** 로 보입니다.
→ 짝 PR: [PrayU-Web#470](https://github.com/TeamVisioneer/PrayU-Web/pull/470) (user_id 필터 명시)

## 검증

- `db reset` 재생 무오류, 정책 2개 `using(true)` 확인
- 본인 1건 + 타인 5건 시드 후 실제 REST 호출:
  - 정책 개방 확인: 전체 조회 `Content-Range: 0-5/6`
  - 앱 쿼리(user_id 필터): `Content-Range: 0-0/1` — 본인 것만

🤖 Generated with [Claude Code](https://claude.com/claude-code)