### PR TITLE
refactor: 공지를 이미지 여러 장 + 본문 하나 구조로

### DIFF
--- a/supabase/functions/_types/database.ts
+++ b/supabase/functions/_types/database.ts
@@ -297,39 +297,42 @@ export type Database = {
       }
       notice: {
         Row: {
+          body: string | null
           created_at: string
           cta_label: string | null
           cta_url: string | null
           ends_at: string | null
           id: string
+          images: Json
           is_active: boolean
-          slides: Json
           starts_at: string
           target: string
           title: string
           updated_at: string
         }
         Insert: {
+          body?: string | null
           created_at?: string
           cta_label?: string | null
           cta_url?: string | null
           ends_at?: string | null
           id?: string
+          images?: Json
           is_active?: boolean
-          slides?: Json
           starts_at?: string
           target?: string
           title: string
           updated_at?: string
         }
         Update: {
+          body?: string | null
           created_at?: string
           cta_label?: string | null
           cta_url?: string | null
           ends_at?: string | null
           id?: string
+          images?: Json
           is_active?: boolean
-          slides?: Json
           starts_at?: string
           target?: string
           title?: string

--- a/supabase/migrations/20260727095106_restructure_notice_images_body.sql
+++ b/supabase/migrations/20260727095106_restructure_notice_images_body.sql
@@ -1,0 +1,52 @@
+-- 공지 구조 정리 (docs: PrayU-web/docs/admin-revamp-plan.md)
+--
+-- 슬라이드마다 본문을 따로 두던 구조(slides: [{image_url, tip, body}])는 과했다.
+-- 실제 공지는 **이미지 여러 장 + 본문 하나**다 — 이미지는 넘겨 보고 설명은 그 아래 한 덩어리.
+alter table "public"."notice"
+    add column "images" jsonb not null default '[]'::jsonb,
+    add column "body" text;
+
+-- 기존 slides 데이터 이관: 이미지는 순서대로 모으고, 본문은 슬라이드별 텍스트를 이어 붙인다
+update "public"."notice" n
+set images = coalesce(sub.images, '[]'::jsonb)
+from (
+    select n2.id,
+           jsonb_agg(s->'image_url' order by ord) filter (
+               where coalesce(s->>'image_url', '') <> ''
+           ) as images
+    from "public"."notice" n2,
+         jsonb_array_elements(n2.slides) with ordinality as t(s, ord)
+    group by n2.id
+) sub
+where n.id = sub.id;
+
+update "public"."notice" n
+set body = sub.body
+from (
+    select n2.id,
+           string_agg(
+               nullif(
+                   concat_ws(
+                       E'\n\n',
+                       nullif(s->>'tip', ''),
+                       coalesce(
+                           nullif(s->>'body', ''),
+                           (
+                               select string_agg(d.value #>> '{}', E'\n')
+                               from jsonb_array_elements(
+                                   coalesce(s->'description', '[]'::jsonb)
+                               ) d
+                           )
+                       )
+                   ),
+                   ''
+               ),
+               E'\n\n' order by ord
+           ) as body
+    from "public"."notice" n2,
+         jsonb_array_elements(n2.slides) with ordinality as t(s, ord)
+    group by n2.id
+) sub
+where n.id = sub.id;
+
+alter table "public"."notice" drop column "slides";


### PR DESCRIPTION
짝 PR: [PrayU-Web#471](https://github.com/TeamVisioneer/PrayU-Web/pull/471) — **Api 먼저 merge**

## 배경

공지를 `slides: [{image_url, tip, body}]`로 두어 **슬라이드마다 본문**을 쓰게 했는데, 실제 공지는 그렇게 읽히지 않습니다. 이미지는 넘겨 보고 설명은 그 아래 **한 덩어리**입니다.

## 변경 내용

- `images jsonb` (URL 배열) + `body text` (마크다운) 추가, `slides` 제거
- 기존 데이터 이관: 이미지는 순서대로 모으고, 본문은 슬라이드별 텍스트(`tip` + `body`)를 빈 줄로 이어 붙입니다. 더 이전 형식(`description` 줄 배열)도 함께 처리합니다

## 검증

구 스키마 상태에서 3가지 케이스를 심고 마이그레이션을 적용해 실측했습니다:

| 입력 | images | body |
|---|---|---|
| 2슬라이드(tip+body) | `[a.png, b.png]` 순서 유지 | 소제목A/본문A/소제목B/본문B 합쳐짐 |
| 구형식(description 배열) | `[c.png]` | 팁C + 줄1·줄2 |
| 빈 슬라이드 | `[]` | null |

`supabase db reset` 재생 무오류, 타입 재생성 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)