### PR TITLE
docs: 어드민 개편 merge 반영 (백로그)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -15,7 +15,7 @@
 
 계획: [PrayU-web/docs/admin-revamp-plan.md](../../PrayU-web/docs/admin-revamp-plan.md) (4개 PR, merge는 **Api 먼저 → web**)
 
-- [x] **PR A** `profiles.is_admin` + `notice` 테이블 + RLS — [#39](https://github.com/TeamVisioneer/PrayU-Api/pull/39) 리뷰 대기
+**어드민 개편 Api 작업은 모두 merge 완료** (#39 · #40 · #41 — 아래 "완료" 절 참조).
 - [x] ~~**PR C** `admin` edge function~~ — **폐기**. 대시보드가 읽을 테이블(`profiles`/`group`/`member`/`pray`/`pray_card`)이 이미 `select using(true)`라 함수를 세워도 실질 보호가 0이고 배포 대상만 늘어난다. 대신 사용 로그 읽기만 개방 → [#40](https://github.com/TeamVisioneer/PrayU-Api/pull/40)
 - [ ] **RLS 전면 정비 시 재검토** — security-backlog 1번으로 `group`/`member`/`pray`/`pray_card`가 잠기면 web 대시보드의 클라이언트 조회가 깨진다. 그때 관리자 select 정책 추가 또는 서버 경유로 전환 판단
 
@@ -25,7 +25,7 @@
 사용자가 자기 프로필의 `premium_expired_at`을 임의 설정해 **프리미엄(그룹 무제한)을 무료로 얻을 수 있다** (로컬 실증 완료).
 `is_admin`과 같은 원인(컬럼을 제한하지 않는 UPDATE 정책)이며, 조치도 같다 — 컬럼 단위 UPDATE 권한 회수.
 지금 못 막는 이유: 어드민 화면이 **클라이언트에서 직접** 이 컬럼에 쓴다 → 잠그면 어드민 기능이 먼저 깨진다.
-→ PR C에서 어드민 쓰기를 함수 경유로 옮긴 뒤 함께 잠근다. 상세: [security-backlog.md](../../PrayU-web/docs/security-backlog.md) 8번
+→ PR C(admin edge function)를 폐기했으므로, 막기로 하면 **어드민 프리미엄 설정만을 위한 최소 서버 경로**를 따로 만들고 컬럼 권한을 회수한다. 상세: [security-backlog.md](../../PrayU-web/docs/security-backlog.md) 8번
 
 ### 기타
 - [ ] QT 응답 토큰을 `llm_usage_log`에 기록 (현재 호출 수만 차감)
@@ -53,6 +53,8 @@
 
 | 날짜 | 내용 | PR |
 |---|---|---|
+| 2026-07-27 | 공지 구조 정리 — `images`(URL 배열) + `body`(마크다운), `slides` 제거 및 데이터 이관 | #41 |
+| 2026-07-27 | 사용 로그(`llm_usage_log`·`share_reward_log`) 읽기 개방 — 어드민 집계용 | #40 |
 | 2026-07-27 | `is_admin` + `notice` 테이블, `is_admin` 자기부여 차단, 공지 노출 조건을 앱으로 이동 | #39 |
 | 2026-07-27 | 카카오 공유 보상 — 웹훅 수신 + 말씀카드 동적 한도 | #38 |
 | 2026-07-26 | QT LLM 일일 한도(10회) | #35 |


### PR DESCRIPTION
Api 쪽 어드민 개편 작업(#39·#40·#41)이 모두 merge되어 백로그를 정리했습니다.

- 진행 중 항목을 완료로 이동
- `premium_expired_at` 항목의 조치 방안 갱신 — PR C를 폐기했으므로, 막기로 하면 어드민 프리미엄 설정만을 위한 최소 서버 경로를 따로 만들어야 한다는 점 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)