### PR TITLE
feat: notice.slug — 레포 원고와 등록된 공지를 잇는 열쇠

### DIFF
--- a/supabase/functions/_types/database.ts
+++ b/supabase/functions/_types/database.ts
@@ -305,6 +305,7 @@ export type Database = {
           id: string
           images: Json
           is_active: boolean
+          slug: string | null
           starts_at: string
           target: string
           title: string
@@ -319,6 +320,7 @@ export type Database = {
           id?: string
           images?: Json
           is_active?: boolean
+          slug?: string | null
           starts_at?: string
           target?: string
           title: string
@@ -333,6 +335,7 @@ export type Database = {
           id?: string
           images?: Json
           is_active?: boolean
+          slug?: string | null
           starts_at?: string
           target?: string
           title?: string

--- a/supabase/migrations/20260728134208_add_notice_slug.sql
+++ b/supabase/migrations/20260728134208_add_notice_slug.sql
@@ -1,0 +1,11 @@
+-- 공지 원고(web 레포 `docs/notices/<slug>.md`)와 등록된 공지를 잇는 열쇠.
+--
+-- 어드민이 레포 원고 목록을 보여주고 "이미 등록됨"을 판단하려면 안정적인 식별자가 필요하다.
+-- 제목으로 맞추면 제목을 고치는 순간 같은 공지가 두 번 등록된다.
+--
+-- 널 허용: 어드민에서 즉석으로 만든 공지는 대응하는 원고가 없다.
+-- (Postgres 의 unique 는 널을 서로 다른 값으로 보므로 즉석 공지끼리는 충돌하지 않는다)
+alter table "public"."notice"
+    add column "slug" text;
+
+create unique index "notice_slug_key" on "public"."notice" ("slug");


### PR DESCRIPTION
짝 PR: web (어드민에서 레포 원고를 초안으로 등록)

## 왜

공지 게시를 **원고 붙여넣기**에서 **레포 원고 목록에서 고르기**로 바꾼다.
어드민이 `docs/notices/<slug>.md` 목록을 보여주고, 누르면 `is_active = false` 초안으로 등록한다.

그러려면 "이 원고가 이미 등록됐는가"를 판단할 식별자가 필요하다.
제목으로 맞추면 제목을 고치는 순간 같은 공지가 두 번 등록된다.

## 무엇

```sql
alter table "public"."notice" add column "slug" text;
create unique index "notice_slug_key" on "public"."notice" ("slug");
```

- **널 허용** — 어드민에서 즉석으로 만든 공지는 대응하는 원고가 없다.
  Postgres 의 unique 는 널을 서로 다른 값으로 보므로 즉석 공지끼리는 충돌하지 않는다
- 스키마만 늘어난다. **공지 내용(서비스 데이터)은 마이그레이션에 들어가지 않는다** — 그게 이 방식을 고른 이유다

## 검증

로컬 적용 후 `information_schema` 확인 (`slug text null=YES`), 타입 재생성 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)