### PR TITLE
feat: 업로드 서명 URL 엔드포인트 + image_key 컬럼

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,18 @@ PrayU 백엔드 — Supabase 마이그레이션·Edge Functions·seed의 주인.
 - 계정 삭제 경로는 만들지 않았다. **회원 탈퇴 자체가 FK 때문에 실패하는 문제**가 있다 → [docs/backlog.md](docs/backlog.md)
 - 상세: [docs/dev-seed-plan.md](docs/dev-seed-plan.md)
 
+## 시크릿
+
+각 환경(staging·prod)에 등록한다. 로컬은 `./.env`.
+
+| 이름 | 쓰는 곳 |
+|---|---|
+| `OPENAI_API_KEY` | bible·openai 함수 |
+| `KAKAO_ADMIN_KEY` | kakao-webhook |
+| `R2_ENDPOINT` · `R2_BUCKET` · `R2_ACCESS_KEY_ID` · `R2_SECRET_ACCESS_KEY` | 업로드 서명 (`POST /api/upload-url`) |
+
+R2 값이 없으면 업로드 엔드포인트가 500 을 돌려준다 — 설정 누락을 조용히 넘기지 않는다.
+
 ## 신규 엔드포인트 체크리스트
 
 함수는 전부 service role 클라이언트(RLS 우회)를 쓰므로 **함수 코드가 권한 검사의 전부**다. 라우트 추가 시:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -58,10 +58,12 @@ FK 를 CASCADE 로 바꿀지, 함수에서 순서대로 지울지, 소프트 삭
 Supabase Storage 무료 한도 1GB. 말씀카드 한 장 ≈ 52KB 라 **1GB ≈ 2만 장**으로 당장 급하지는 않지만,
 쌓인 뒤 옮기면 객체 복사 + DB URL 일괄 치환이 필요해 비싸진다. **신규 업로드만 R2 로** 돌려 그 비용을 없앤다.
 
-- [ ] **사람이 준비** — R2 버킷 2개(staging/prod), API 토큰, `r2.dev` 공개 설정, **CORS 허용**, 환경별 시크릿 등록
-      (`R2_ACCOUNT_ID` · `R2_ACCESS_KEY_ID` · `R2_SECRET_ACCESS_KEY` · `R2_BUCKET`)
-- [ ] **Api** — 서명 URL 발급 엔드포인트 (`POST /api/upload-url`). 경로를 클라이언트가 정하지 못하게 서버가 키를 만든다
-- [ ] web 짝 — 경로(key) 저장 + `assetUrl()` 리졸버, 업로드 전환
+- [x] ~~**0단계 · 업로드 전 리사이즈**~~ — [PrayU-Web#488](https://github.com/TeamVisioneer/PrayU-Web/pull/488). 폰 사진 6.75MB → 484KB
+- [x] ~~**Api** — `image_key` 마이그레이션 + 서명 URL 엔드포인트~~ — [#50](https://github.com/TeamVisioneer/PrayU-Api/pull/50)
+- [ ] 🔴 **사람이 준비** — R2 버킷 2개(staging/prod), API 토큰, `r2.dev` 공개 설정, **CORS 허용**,
+      환경별 시크릿 등록 (`R2_ENDPOINT` · `R2_BUCKET` · `R2_ACCESS_KEY_ID` · `R2_SECRET_ACCESS_KEY`).
+      **이게 없으면 엔드포인트가 500 을 돌려준다** — 배포해도 web 전환 전까지는 아무도 호출하지 않으므로 순서는 자유다
+- [ ] web 짝 — 경로(key) 저장 + `assetUrl()`, 업로드 전환
 
 ### `premium_expired_at` 자기부여 차단 — 사용자 판단 대기
 사용자가 자기 프로필의 `premium_expired_at`을 임의 설정해 **프리미엄(그룹 무제한)을 무료로 얻을 수 있다** (로컬 실증 완료).

--- a/supabase/functions/_types/database.ts
+++ b/supabase/functions/_types/database.ts
@@ -77,6 +77,7 @@ export type Database = {
           colors: string[]
           created_at: string
           id: string
+          image_key: string | null
           image_url: string | null
           keywords: string[]
           name: string
@@ -89,6 +90,7 @@ export type Database = {
           colors?: string[]
           created_at?: string
           id?: string
+          image_key?: string | null
           image_url?: string | null
           keywords?: string[]
           name?: string
@@ -101,6 +103,7 @@ export type Database = {
           colors?: string[]
           created_at?: string
           id?: string
+          image_key?: string | null
           image_url?: string | null
           keywords?: string[]
           name?: string
@@ -662,6 +665,7 @@ export type Database = {
           deleted_at: string | null
           id: number
           image: string
+          image_key: string | null
           updated_at: string
           user_name: string
         }
@@ -671,6 +675,7 @@ export type Database = {
           deleted_at?: string | null
           id?: number
           image?: string
+          image_key?: string | null
           updated_at?: string
           user_name?: string
         }
@@ -680,6 +685,7 @@ export type Database = {
           deleted_at?: string | null
           id?: number
           image?: string
+          image_key?: string | null
           updated_at?: string
           user_name?: string
         }

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -1,11 +1,13 @@
 import { Hono } from "https://deno.land/x/hono@v4.3.11/mod.ts";
 import userRouter from "./users/userRouter.ts";
 import churchRouter from "./churches/churchRouter.ts";
+import uploadRouter from "./upload/uploadRouter.ts";
 
 const app = new Hono();
 
 app.basePath("/api")
   .route("/users", userRouter)
-  .route("/churches", churchRouter);
+  .route("/churches", churchRouter)
+  .route("/upload-url", uploadRouter);
 
 Deno.serve(app.fetch);

--- a/supabase/functions/api/upload/uploadController.ts
+++ b/supabase/functions/api/upload/uploadController.ts
@@ -1,0 +1,89 @@
+import { Context } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { corsHeaders } from "../../_shared/cors.ts";
+import { presignPutUrl } from "./uploadService.ts";
+
+/** 올릴 수 있는 용도. 경로를 클라이언트가 정하지 못하게 이 목록으로 제한한다 */
+const KINDS = ["bible_card", "thanks_card", "notice"] as const;
+type Kind = (typeof KINDS)[number];
+
+/** 허용 타입 → 확장자. 목록에 없으면 거부한다 */
+const EXTENSIONS: Record<string, string> = {
+  "image/jpeg": "jpeg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+const json = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+export class UploadController {
+  /**
+   * 사전 서명 PUT URL 을 발급한다.
+   *
+   * 브라우저는 이 URL 로 파일 본문만 올리고, DB 에는 함께 받은 `key` 를 저장한다.
+   * 공개 주소는 앱이 환경변수와 조합해 만든다 — 스토리지 도메인이 DB 에 박히지 않게.
+   */
+  async createUploadUrlV1(c: Context) {
+    const userId = c.get("userId");
+    // 업로드는 로그인 사용자만. 인프라 호출자도 쓸 일이 없다
+    if (!userId || userId === "anon" || userId === "service_role") {
+      return json({ data: null, error: "Unauthorized" }, 401);
+    }
+
+    let body: { kind?: string; contentType?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return json({ data: null, error: "Invalid body" }, 400);
+    }
+
+    const { kind, contentType } = body;
+    if (!kind || !KINDS.includes(kind as Kind)) {
+      return json(
+        { data: null, error: `kind must be one of ${KINDS.join(", ")}` },
+        400,
+      );
+    }
+    const extension = contentType ? EXTENSIONS[contentType] : undefined;
+    if (!extension) {
+      return json(
+        {
+          data: null,
+          error: `contentType must be one of ${Object.keys(EXTENSIONS).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const endpoint = Deno.env.get("R2_ENDPOINT");
+    const bucket = Deno.env.get("R2_BUCKET");
+    const accessKeyId = Deno.env.get("R2_ACCESS_KEY_ID");
+    const secretAccessKey = Deno.env.get("R2_SECRET_ACCESS_KEY");
+    if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+      console.error("R2 secrets are not configured");
+      return json({ data: null, error: "Storage is not configured" }, 500);
+    }
+
+    // 키는 **서버가** 만든다. 클라이언트가 경로를 정하면 남의 파일을 덮어쓸 수 있다
+    const key = `${kind}/${crypto.randomUUID()}.${extension}`;
+
+    try {
+      const url = await presignPutUrl({
+        endpoint,
+        bucket,
+        key,
+        accessKeyId,
+        secretAccessKey,
+        contentType,
+      });
+      return json({ data: { url, key }, error: null }, 200);
+    } catch (error) {
+      console.error("Failed to presign upload url:", error);
+      return json({ data: null, error: "Failed to create upload url" }, 500);
+    }
+  }
+}

--- a/supabase/functions/api/upload/uploadRouter.ts
+++ b/supabase/functions/api/upload/uploadRouter.ts
@@ -1,0 +1,11 @@
+import { Hono } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { UploadController } from "./uploadController.ts";
+import { authMiddleware } from "../../_shared/authMiddleware.ts";
+
+const uploadRouter = new Hono();
+const uploadController = new UploadController();
+
+uploadRouter.use("*", authMiddleware);
+uploadRouter.post("/", (c) => uploadController.createUploadUrlV1(c));
+
+export default uploadRouter;

--- a/supabase/functions/api/upload/uploadService.ts
+++ b/supabase/functions/api/upload/uploadService.ts
@@ -1,0 +1,122 @@
+/**
+ * S3 호환 스토리지(Cloudflare R2)용 **사전 서명 PUT URL** 발급.
+ *
+ * R2 에는 RLS 가 없다. 브라우저가 직접 올리게 하려면 서버가 "이 키에, 이 타입으로,
+ * 이 시간 안에만" 이라고 서명한 URL 을 내줘야 한다. 시크릿은 함수에만 있고 브라우저로 나가지 않는다.
+ *
+ * AWS Signature Version 4 (query string 방식). R2 는 S3 API 를 그대로 받는다.
+ * 같은 규격이라 로컬 Supabase 의 S3 호환 엔드포인트로도 검증할 수 있다.
+ */
+
+const encoder = new TextEncoder();
+
+const sha256Hex = async (data: string): Promise<string> => {
+  const buf = await crypto.subtle.digest("SHA-256", encoder.encode(data));
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+const hmac = async (key: ArrayBuffer | Uint8Array, data: string) => {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key as ArrayBuffer,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data));
+};
+
+const hex = (buf: ArrayBuffer): string =>
+  [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+/** 경로의 각 구간을 인코딩한다. `/` 는 구분자로 남긴다 */
+const encodeKey = (key: string): string =>
+  key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+export interface PresignOptions {
+  endpoint: string; // 예: https://<account>.r2.cloudflarestorage.com
+  bucket: string;
+  key: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region?: string;
+  /** 유효 시간(초). 짧게 둔다 — 발급 후 바로 올리는 용도다 */
+  expiresIn?: number;
+  /** 서명에 묶어 다른 타입으로 올리지 못하게 한다 */
+  contentType: string;
+  /** 서명 시각. 테스트에서 고정하기 위해 주입 가능하게 둔다 */
+  now?: Date;
+}
+
+export const presignPutUrl = async ({
+  endpoint,
+  bucket,
+  key,
+  accessKeyId,
+  secretAccessKey,
+  region = "auto",
+  expiresIn = 300,
+  contentType,
+  now = new Date(),
+}: PresignOptions): Promise<string> => {
+  const service = "s3";
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // 20260729T072300Z
+  const dateStamp = amzDate.slice(0, 8);
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+
+  const url = new URL(endpoint);
+  const host = url.host;
+  // 엔드포인트에 경로가 붙어 있을 수 있다 (R2 는 없지만, S3 호환 구현 중에는 있다).
+  // 서명 대상 경로에 그 접두사를 포함해야 검증이 통과한다.
+  const prefix = url.pathname === "/" ? "" : url.pathname.replace(/\/$/, "");
+  const canonicalUri = `${prefix}/${encodeKey(bucket)}/${encodeKey(key)}`;
+
+  // content-type 도 서명에 포함한다 — 발급받은 URL 로 다른 타입을 올리지 못한다
+  const signedHeaders = "content-type;host";
+  const canonicalHeaders = `content-type:${contentType}\nhost:${host}\n`;
+
+  const query = new URLSearchParams({
+    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+    "X-Amz-Credential": `${accessKeyId}/${scope}`,
+    "X-Amz-Date": amzDate,
+    "X-Amz-Expires": String(expiresIn),
+    "X-Amz-SignedHeaders": signedHeaders,
+  });
+  // AWS 는 쿼리 파라미터가 키 순으로 정렬돼 있기를 요구한다
+  const canonicalQuery = [...query.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+
+  const canonicalRequest = [
+    "PUT",
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    await sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  let signingKey = await hmac(
+    encoder.encode(`AWS4${secretAccessKey}`),
+    dateStamp,
+  );
+  for (const part of [region, service, "aws4_request"]) {
+    signingKey = await hmac(signingKey, part);
+  }
+  const signature = hex(await hmac(signingKey, stringToSign));
+
+  return `${url.origin}${canonicalUri}?${canonicalQuery}&X-Amz-Signature=${signature}`;
+};

--- a/supabase/migrations/20260729072623_add_image_key.sql
+++ b/supabase/migrations/20260729072623_add_image_key.sql
@@ -1,0 +1,13 @@
+-- 스토리지에 올린 파일을 **경로(key)** 로 가리킨다.
+--
+-- 기존 컬럼(`image_url`·`image`)에는 절대 URL 이 들어 있다. 그 값에 키를 섞어 넣고
+-- 생김새로 구분하는 방법도 있으나, 한 컬럼에 두 의미가 섞이면 판별에 안 맞는 값이
+-- 하나만 들어와도 조용히 깨진다. 컬럼을 나눈다 — 읽을 때는 키가 있으면 키를, 없으면 기존 URL 을 쓴다.
+--
+-- 공개 주소는 앱의 환경변수(VITE_ASSET_BASE_URL)와 조합해 만든다.
+-- 스토리지 도메인이 바뀌어도 DB 를 건드리지 않기 위해서다. (docs/storage-r2-plan.md)
+alter table "public"."bible_card"
+    add column "image_key" text;
+
+alter table "public"."thanks_card"
+    add column "image_key" text;


### PR DESCRIPTION
계획: [docs/storage-r2-plan.md](docs/storage-r2-plan.md) 의 **2단계** · 0단계(리사이즈)는 [PrayU-Web#488](https://github.com/TeamVisioneer/PrayU-Web/pull/488) 로 완료

## 무엇

| 파일 | 내용 |
|---|---|
| `migrations/…_add_image_key.sql` | `bible_card.image_key` · `thanks_card.image_key` |
| `functions/api/upload/uploadService.ts` | AWS SigV4 쿼리 서명 (R2 는 S3 API 를 그대로 받는다) |
| `functions/api/upload/uploadController.ts` | 권한·입력 검사, **키 생성** |
| `functions/api/upload/uploadRouter.ts` · `index.ts` | `POST /api/upload-url` |
| `CLAUDE.md` | 시크릿 대장에 R2 항목 |

## 권한 검사 (신규 엔드포인트 체크리스트)

- **로그인 사용자만.** `anon`·`service_role` 은 401 — 인프라 호출자가 쓸 일이 없다
- **키는 서버가 만든다** (`<kind>/<uuid>.<ext>`). 클라이언트가 경로를 정하면 남의 파일을 덮어쓸 수 있다
- `kind` 는 `bible_card`·`thanks_card`·`notice` 로 제한, `contentType` 은 이미지 4종만
- **contentType 을 서명에 묶었다** — 발급받은 URL 로 다른 타입을 올릴 수 없다
- 유효시간 5분

## 검증

로컬 Supabase 에 **S3 호환 엔드포인트**가 있어 서명 규격이 같다. R2 자격증명 없이 그대로 확인했다.

| 시나리오 | 결과 |
|---|---|
| 발급 URL 로 업로드 | **200** |
| 같은 URL에 content-type 만 바꿔 업로드 | **403** |
| 만료된 서명 | **400** |
| 업로드한 파일 공개 조회 | **200** |
| 엔드포인트 — 비로그인 | **401** |
| 엔드포인트 — `kind: "../../etc"` | **400** |
| 엔드포인트 — `contentType: text/html` | **400** |

> 서명에는 host 가 포함된다. 테스트 중 호스트를 바꿔 호출했다가 403 을 봤는데, `--resolve` 로
> 이름만 해석하니 통과했다 — 서명이 의도대로 호스트까지 묶고 있다는 뜻이다.

## 배포 후

**R2 시크릿이 없으면 이 엔드포인트는 500 을 돌려준다** (설정 누락을 조용히 넘기지 않는다).
아직 web 이 호출하지 않으므로 지금 배포해도 사용자 영향은 없다. 시크릿 등록은 backlog 에 🔴 로 올렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)