### PR TITLE
docs: R2 설정 반영 — 환경변수 이름, CORS 오리진 정정, 시크릿 CI 화 백로그

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -71,6 +71,20 @@ Supabase Storage 무료 한도 1GB. 말씀카드 한 장 ≈ 52KB 라 **1GB ≈ 
 지금 못 막는 이유: 어드민 화면이 **클라이언트에서 직접** 이 컬럼에 쓴다 → 잠그면 어드민 기능이 먼저 깨진다.
 → PR C(admin edge function)를 폐기했으므로, 막기로 하면 **어드민 프리미엄 설정만을 위한 최소 서버 경로**를 따로 만들고 컬럼 권한을 회수한다. 상세: [security-backlog.md](../../PrayU-web/docs/security-backlog.md) 8번
 
+### 함수 시크릿을 CI 로 주입 — 검토
+지금 Edge Function 시크릿(`OPENAI_SECRET_KEY`·`KAKAO_ADMIN_KEY`·`R2_*` 등)은 **대시보드에 사람이 손으로** 넣는다.
+staging/prod 에 뭔가 반영되는 경로 중 **유일하게 CI 를 안 거치는 예외**이고, 그래서 두 문제가 있다 —
+레포만 봐서는 어떤 시크릿이 필요한지 알 수 없고(코드의 `Deno.env.get` 을 다 찾아야 한다),
+staging 에 넣고 prod 에 빠뜨리면 **release 후 500 이 날 때** 알게 된다.
+
+배포 워크플로에 `supabase secrets set --project-ref $PROJECT_ID --env-file` 단계를 넣으면
+**이름은 git(워크플로 파일)에, 값은 GitHub Secrets 에** 남고 두 환경이 같은 목록을 갖는다.
+
+- [ ] **선행 확인**: `supabase secrets set` 이 지정한 것만 갱신하는지, 나머지를 지우는지 staging 에서 실증.
+      지운다면 워크플로에 **모든** 시크릿을 나열해야 한다 (누락 시 기존 시크릿이 날아간다)
+- [ ] 배포 워크플로 수정이라 **사람 확인 후 진행**. 시크릿 보관처가 하나 늘어나는 대가(로테이션 시 GitHub 도 갱신)를 감수할지 판단 필요
+- 판단 보류 근거: 시크릿이 4~6개 수준이면 사람이 관리 가능한 규모다. 개수가 늘거나 환경이 추가되면 그때 한다
+
 ### 기타
 - [ ] QT 응답 토큰을 `llm_usage_log`에 기록 (현재 호출 수만 차감)
 - [ ] `deno.lock` 커밋 여부 결정

--- a/docs/storage-r2-plan.md
+++ b/docs/storage-r2-plan.md
@@ -79,7 +79,7 @@ Supabase Storage 무료 한도가 **1GB**이고, **2026-07-29 기준 이미 0.26
 
 ```
 기존:  image_url = "https://<ref>.supabase.co/storage/v1/object/public/prayu/BibleCard/a.jpeg"
-신규:  image_key = "bible_card/9f2c….jpeg"    + VITE_ASSET_BASE_URL (환경변수)
+신규:  image_key = "bible_card/9f2c….jpeg"    + VITE_STORAGE_BASE_URL (환경변수)
 ```
 
 도메인이 바뀌면 **환경변수 한 줄**만 고치면 된다. 공지 이미지에서 겪은
@@ -101,7 +101,7 @@ Supabase Storage 무료 한도가 **1GB**이고, **2026-07-29 기준 이미 0.26
 ```ts
 // src/lib/assetUrl.ts — 키만 받는다. URL 을 넘기는 경우는 없다.
 export const assetUrl = (key: string | null): string | null =>
-  key ? `${import.meta.env.VITE_ASSET_BASE_URL}/${key}` : null;
+  key ? `${import.meta.env.VITE_STORAGE_BASE_URL}/${key}` : null;
 
 // 읽는 곳
 const src = assetUrl(card.image_key) ?? card.image_url;
@@ -182,7 +182,7 @@ R2 에는 RLS 가 없으므로 **서명 URL 을 내주는 엔드포인트**가 �
 | `src/pages/NewThanksCardPage.tsx` · `BibleCardPage/BibleCardNewPage.tsx` · `BibleCardGeneratorPage.tsx` (수정) | 저장 시 key 를 넣는다 |
 | `src/pages/AdminPage/NoticeManager.tsx` (수정) | 즉석 공지 이미지 업로드도 같은 경로로. **단 저장은 URL** — 아래 참조 |
 | 읽는 곳 (수정) | `PrayCardHistoryDrawer` · `PrayCardHistoryList` · `ThanksCardItem` — `assetUrl(image_key) ?? image_url` 로. **`UserProfile`·`PrayListDrawer`·`PrayCard` 는 손대지 않는다**(`avatar_url` 만 쓴다) |
-| `.env` (각 환경) | `VITE_ASSET_BASE_URL` |
+| `.env` (각 환경) | `VITE_STORAGE_BASE_URL` |
 
 **프로필 사진**: `avatar_url` 은 대부분 카카오가 준 외부 URL 이라 이번 범위 밖이다. 관련 컴포넌트는 건드리지 않는다.
 
@@ -197,9 +197,9 @@ R2 에는 RLS 가 없으므로 **서명 URL 을 내주는 엔드포인트**가 �
 2. [x] **Api PR** — `image_key` 마이그레이션 + 서명 엔드포인트 — [#50](https://github.com/TeamVisioneer/PrayU-Api/pull/50)
 3. [x] **web PR** — `assetUrl()` + 업로드 전환 + 읽는 곳 정리 — [PrayU-Web#489](https://github.com/TeamVisioneer/PrayU-Web/pull/489)
 1. [ ] 🔴 **사람이 준비** — R2 버킷 2개(staging/prod), API 토큰, `r2.dev` 공개 설정, **CORS 허용**(브라우저 PUT 이므로 필수),
-   Api 시크릿 4개 + web `VITE_ASSET_BASE_URL`
+   Api 시크릿 4개 + web `VITE_STORAGE_BASE_URL`
 4. [ ] **검증** — 아래
-5. (나중에) 도메인을 옮기게 되면 `VITE_ASSET_BASE_URL` 만 바꾼다
+5. (나중에) 도메인을 옮기게 되면 `VITE_STORAGE_BASE_URL` 만 바꾼다
 
 **순서가 뒤집혔다.** 1단계(사람이 준비)를 기다리지 않고 코드를 먼저 넣었으므로,
 **설정이 없는 동안에는 기존 Supabase Storage 로 계속 업로드된다** (아래 "스위치" 절).
@@ -207,7 +207,7 @@ R2 에는 RLS 가 없으므로 **서명 URL 을 내주는 엔드포인트**가 �
 
 ### 스위치 — 설정이 없으면 옛 경로로 간다
 
-`VITE_ASSET_BASE_URL` **하나로** 판단한다.
+`VITE_STORAGE_BASE_URL` **하나로** 판단한다.
 
 | 상태 | 업로드 | DB 에 들어가는 값 |
 |---|---|---|

--- a/docs/storage-r2-plan.md
+++ b/docs/storage-r2-plan.md
@@ -66,6 +66,8 @@ Supabase Storage 무료 한도가 **1GB**이고, **2026-07-29 기준 이미 0.26
   (*"you will not be able to access Vercel Blob if limits are exceeded"*). 사용자 업로드가 멈춘다는 뜻이라
   무료 플랜으로는 위험하다. 커스텀 도메인도 지원하지 않는다. Pro 로 올린다면 다시 볼 만하다
 - **R2 + `file.prayu.site`** — R2 커스텀 도메인은 **해당 도메인이 같은 Cloudflare 계정의 zone** 이어야 한다.
+  DNS 를 Vercel 에 두고 zone 만 등록하는 partial(CNAME) setup 은 **Business 플랜 이상**,
+  하위 도메인만 위임하는 subdomain setup 은 **Enterprise 전용** (2026-07 Cloudflare 문서 확인).
   서브도메인만 위임하는 partial(CNAME) setup 은 **Business/Enterprise 전용**이라 무료로는 불가능하다.
   prayu.site 를 통째로 옮기는 선택지는 DNS 통합 관리 방침과 어긋나 접었다
 
@@ -239,7 +241,11 @@ R2 에는 RLS 가 없으므로 **서명 URL 을 내주는 엔드포인트**가 �
 ### R2 연결 후 확인할 것
 
 - 말씀카드·감사카드·즉석 공지 이미지 업로드 → R2 에 객체 생성 확인, DB 에 **키만** 저장됐는지 확인
-- **CORS** — 브라우저 PUT 이라 버킷에 허용 오리진이 없으면 여기서 막힌다 (로컬 검증으로는 드러나지 않는 항목)
+- **CORS** — 브라우저 PUT 이라 버킷에 허용 오리진이 없으면 여기서 막힌다 (로컬 검증으로는 드러나지 않는 항목).
+  실제 오리진은 staging `https://staging.prayu.site`, prod `https://prayu.site` + `https://www.prayu.site`
+  (+ 로컬 `http://localhost:5173`). `prayu-staging.vercel.app` 이 아니다 — 처음에 이걸로 잘못 적었다
+- `<img>` 로 보여주는 건 CORS 를 타지 않지만 **`fetch()` 로 읽으면 GET 도 CORS 를 탄다.**
+  지금은 전부 `<img>` 라 `PUT` 만 열어두면 되고, 캔버스 합성 등으로 이미지를 `fetch` 하게 되면 `GET` 을 추가한다
 - **기존 카드가 그대로 보이는지** — `image_key` 가 없는 행은 `image_url` 로 떨어져야 한다
 - 카카오 공유 썸네일이 새 URL 로 뜨는지
 - 비로그인 상태에서 서명 엔드포인트가 401 인지


### PR DESCRIPTION
R2 를 실제로 붙이면서 확인된 것들을 문서에 반영한다. 코드 변경 없음.

## 1. 환경변수 이름
`VITE_ASSET_BASE_URL` → **`VITE_STORAGE_BASE_URL`** (계획서 6곳). 코드 쪽은 [PrayU-Web#489](https://github.com/TeamVisioneer/PrayU-Web/pull/489).

## 2. CORS 오리진 정정 🔴
처음에 `prayu-staging.vercel.app` 으로 적었는데 **실제 도메인이 다르다.** 그대로 뒀으면 staging 업로드가 막혔다.

| 환경 | 오리진 |
|---|---|
| staging | `https://staging.prayu.site` |
| prod | `https://prayu.site` · `https://www.prayu.site` (둘 다 200) |
| 로컬 | `http://localhost:5173` |

`<img>` 는 CORS 를 타지 않지만 **`fetch()` 로 읽으면 GET 도 탄다** — 로컬 검증 중 실제로 걸렸다. 지금은 전부 `<img>` 라 `PUT` 만 열면 된다.

## 3. 커스텀 도메인이 막히는 이유 (플랜 조건)
R2 커스텀 도메인은 도메인이 **같은 Cloudflare 계정의 zone** 이어야 한다. DNS 는 Vercel 에 두기로 했으므로:

- partial(CNAME) setup — **Business 이상**
- subdomain setup(`file.prayu.site` 만 위임) — **Enterprise 전용**

그래서 `r2.dev` 으로 간다. 되돌리는 비용은 환경변수 한 줄이다.

## 4. 함수 시크릿 CI 주입 — backlog 에 검토 항목 추가
시크릿은 원격 반영 경로 중 **유일하게 CI 를 안 거치는 예외**다. 옮길지 판단할 근거와,
선행 확인 사항(`supabase secrets set` 이 기존 시크릿을 지우는지)을 남겼다. **이번에는 대시보드로 넣는다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)