### PR TITLE
chore: 원격 쓰기·merge·push 를 권한 규칙으로 막는다

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "ask": [
+      "Bash(gh pr merge:*)",
+      "Bash(gh api:*)",
+      "Bash(git push:*)"
+    ],
+    "deny": [
+      "Bash(supabase link:*)",
+      "Bash(supabase db push:*)",
+      "Bash(supabase db reset --linked:*)",
+      "Bash(supabase db remote:*)",
+      "Bash(supabase migration up --linked:*)",
+      "Bash(supabase secrets set:*)",
+      "Bash(supabase secrets unset:*)",
+      "Bash(supabase functions deploy:*)",
+      "Bash(supabase functions delete:*)",
+      "Bash(supabase projects delete:*)",
+      "Bash(supabase branches:*)",
+      "Bash(supabase domains:*)",
+      "Bash(vercel env add:*)",
+      "Bash(vercel env rm:*)",
+      "Bash(vercel deploy:*)",
+      "Bash(vercel promote:*)",
+      "Bash(vercel rollback:*)",
+      "Bash(vercel link:*)",
+      "Bash(vercel alias:*)"
+    ]
+  }
+}


### PR DESCRIPTION
짝 PR: PrayU-Web (같은 파일)

[#51](https://github.com/TeamVisioneer/PrayU-Api/pull/51) 로 `CLAUDE.md` 에 merge 규칙을 넣었지만, **문서는 지켜야 성립한다.**
실제로 한 번 실패했으므로(요청 없는 merge + main 직접 push) 설정으로도 강제한다.

## `deny` — 원격을 바꾸는 명령

`supabase link` · `db push` · `db remote` · `migration up --linked` · `secrets set/unset` ·
`functions deploy/delete` · `projects delete` · `branches` · `domains`
`vercel env add/rm` · `deploy` · `promote` · `rollback` · `link` · `alias`

**읽기는 열어둔다.** `supabase secrets list` 로 시크릿 이름을 대조하는 식의 교차검증은 실제로 유용했다
(R2 시크릿 8개를 해시로 대조해 오타 없음을 확인).

> Supabase 는 CLI 토큰에 스코프가 없고(Read-Only 역할은 Team 플랜 이상), 토큰 수준에서 읽기 전용을
> 만들 방법이 없다. 그래서 이 레이어에서 막는다.

## `ask` — 사람 승인을 받는 명령

`gh pr merge` · `gh api` · `git push`

- `git push` 는 **브랜치를 가리지 않고 전부** 대상이다. main 에 서서 인자 없이 `git push` 한 것이
  실제 사고였고, `git push * main` 같은 인자 패턴으로는 그 경우를 못 잡는다
- `gh api` 를 넣은 이유는 `gh api --method PUT .../merge` 로 우회가 가능해서다

## 한계

Bash 명령 문자열 패턴 매칭이라 **완전한 격리가 아니다.** 표현을 바꾸거나 스크립트로 감싸면 빠져나갈 수 있다.
막아주는 것은 "실수로 밟는 것"이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)