### PR TITLE
feat: premium_expired_at 자기부여 차단 — 서버 경로 + 컬럼 권한 회수

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,9 @@ PrayU 백엔드 — Supabase 마이그레이션·Edge Functions·seed의 주인.
 | `handle_new_user()` + `auth.users`의 `on_auth_user_created` 트리거 | 가입 시 `profiles` 행 생성 (`full_name`/`avatar_url`을 `raw_user_meta_data`에서 복사) | `auth.users` INSERT는 GoTrue 내부에서 일어나 앱이 개입할 지점이 없다 |
 | `update_avatar_url_to_https()` + `profiles`의 `avatar_url_https_trigger` | `avatar_url`이 `http://`면 `https://`로 치환 | 데이터 정규화. 카카오가 http URL을 주던 시절의 방어이며, 앱 여러 경로(가입·프로필 수정)에 흩어 넣는 것보다 한 곳이 안전 |
 | `rls_auto_enable` 이벤트 트리거 | 새 테이블 생성 시 RLS 자동 활성화 | 실수 방지 가드. 마이그레이션 작성자가 RLS를 잊어도 기본이 잠긴 상태가 된다 |
-| `profiles`의 컬럼 단위 UPDATE 권한 (`is_admin` 제외) | 사용자가 자기 `is_admin`을 켜는 **권한 상승** 차단 | RLS 정책은 "행"만 가리고 컬럼을 못 가린다. 앱에서 막으면 클라이언트가 직접 PostgREST를 호출해 우회 가능 — **앱에서는 구조적으로 불가능한 방어** |
+| `profiles`의 컬럼 단위 UPDATE 권한 (`is_admin`·`premium_expired_at` 제외) | 자기 `is_admin`(권한 상승)·`premium_expired_at`(프리미엄 무료 취득) 설정 차단. 어드민의 프리미엄 쓰기는 `POST /api/admin/premium` 으로 | RLS 정책은 "행"만 가리고 컬럼을 못 가린다. 앱에서 막으면 클라이언트가 직접 PostgREST를 호출해 우회 가능 — **앱에서는 구조적으로 불가능한 방어** |
 | RLS 정책 전반 | 행 가시성·쓰기 권한 | 권한이지 비즈니스 로직이 아니다. 단, 조건에 상태·기간 같은 규칙이 섞이면 앱으로 옮긴다 |
 | prod `cron.job` (오늘의 기도 리마인더) | 스케줄에 맞춰 edge function 호출 | 스케줄러. 로직은 호출되는 함수(TS)에 있다 |
-
-**예정**: `premium_expired_at`도 같은 이유(권한 상승·매출 직결)로 컬럼 권한 회수 예정 —
-어드민 쓰기를 `admin` edge function으로 옮긴 뒤. 상세: `docs/backlog.md`
 
 ## 로컬 개발 데이터
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -113,7 +113,18 @@ staging 에 넣고 prod 에 빠뜨리면 **release 후 500 이 날 때** 알게 
 - [ ] **카카오 콘솔 웹훅 등록(prod)** — Api release 후 `https://qggewtakkrwcclyxtxnz.supabase.co/functions/v1/kakao-webhook`, 메서드 **POST**. staging은 등록 완료
 - [ ] **`KAKAO_ADMIN_KEY` 시크릿 확인** — 각 환경 시크릿이 해당 카카오 앱 어드민 키와 일치하는지
 - [ ] **카카오 [플랫폼] > [Web] 사이트 도메인** — prod 앱에 서비스 도메인 등록 확인 (staging에서 4019 `domain mismatched`로 겪은 항목)
-- [ ] **prod 대시보드에서 `push` 함수 수동 삭제** — 코드에서는 제거됨(web#37 짝 작업)
+- [ ] 🔴 **코드에 없는데 배포된 채 살아있는 edge function 3개 삭제** (2026-07-31 `functions list` 로 확인)
+
+  | 함수 | staging | prod | 정체 |
+  |---|---|---|---|
+  | `delete-user` | v20 ACTIVE | **v13 ACTIVE** | 2024년. entrypoint 가 옛 레포 경로(`PrayU-Web/...`) — **레포에 코드가 없는 계정 삭제 엔드포인트** |
+  | `push` | v50 ACTIVE | **v21 ACTIVE** | Firebase 푸시. 코드는 #37 에서 제거 |
+  | `bulk-push` | v12 ACTIVE | 없음 | Firebase 대량 푸시 |
+
+  셋 다 `verify_jwt: true` 로 살아 있고, `FIREBASE_*` 시크릿도 양쪽에 남아 있어 **호출하면 실제로 동작할 수 있다.**
+  `delete-user` 는 소프트 삭제로 정비한 탈퇴 정책([plans/premium-guard.md] 아님 — [archive/account-deletion-plan.md](archive/account-deletion-plan.md))을 우회하는 경로다.
+- [ ] **`FIREBASE_CLIENT_EMAIL`·`FIREBASE_PRIVATE_KEY`·`FIREBASE_PROJECT_ID` 시크릿 제거** (staging·prod) —
+      읽는 코드가 0건이다. 위 함수 3개 삭제 후 진행
 - [ ] 🔴 **운영 관리자 계정에 `is_admin = true` 설정** — **prod release 직후 반드시.** 안 하면 `/admin`이 아무도 못 들어간다(이메일 하드코딩을 걷어내고 이 값만 본다). staging은 2026-07-27 처리 완료
   ```sql
   update public.profiles p set is_admin = true

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -80,11 +80,12 @@ Supabase Storage 무료 한도 1GB. **신규 업로드만 R2 로** 돌려 이전
 **이 작업은 끝났다.** 남은 것은 prod release 뿐이며, 그때 R2 가 prod 에서도 켜진다.
 기존 Supabase 파일은 그대로 서빙되고, 옮길지 여부는 별도 판단 (계획서의 "기존 이미지는 이번에 건드리지 않는다" 절).
 
-### `premium_expired_at` 자기부여 차단 — 사용자 판단 대기
-사용자가 자기 프로필의 `premium_expired_at`을 임의 설정해 **프리미엄(그룹 무제한)을 무료로 얻을 수 있다** (로컬 실증 완료).
-`is_admin`과 같은 원인(컬럼을 제한하지 않는 UPDATE 정책)이며, 조치도 같다 — 컬럼 단위 UPDATE 권한 회수.
-지금 못 막는 이유: 어드민 화면이 **클라이언트에서 직접** 이 컬럼에 쓴다 → 잠그면 어드민 기능이 먼저 깨진다.
-→ PR C(admin edge function)를 폐기했으므로, 막기로 하면 **어드민 프리미엄 설정만을 위한 최소 서버 경로**를 따로 만들고 컬럼 권한을 회수한다. 상세: [security-backlog.md](../../PrayU-web/docs/security-backlog.md) 8번
+### `premium_expired_at` 자기부여 차단 — 진행 중 (v1.0.0 포함)
+계획: [plans/premium-guard.md](plans/premium-guard.md) · 상세: [security-backlog.md](../../PrayU-web/docs/security-backlog.md) 8번
+
+- [x] ~~Api — `POST /api/admin/premium` + 컬럼 권한 회수 마이그레이션~~ — #59
+- [ ] web 짝 — `OperationsTab` 서버 경로 전환 (Api merge 후)
+- [ ] `VITE_PREMIUM_PLAN_USERLIST` Vercel 환경변수 정리 — 코드에서 더 이상 안 읽는다 (사람 조작)
 
 ### 함수 시크릿을 CI 로 주입 — 검토
 지금 Edge Function 시크릿(`OPENAI_SECRET_KEY`·`KAKAO_ADMIN_KEY`·`R2_*` 등)은 **대시보드에 사람이 손으로** 넣는다.

--- a/docs/plans/premium-guard.md
+++ b/docs/plans/premium-guard.md
@@ -1,0 +1,86 @@
+# `premium_expired_at` 자기부여 차단 계획
+
+security-backlog **8번**. v1.0.0 포함분.
+
+## 구멍
+
+`profiles` 의 컬럼 단위 UPDATE 권한 목록(#39 마이그레이션)에 `premium_expired_at` 이 **들어 있다**.
+
+```sql
+grant update ( ..., app_settings, premium_expired_at ) on profiles to authenticated;
+```
+
+로그인한 사용자가 PostgREST 로 자기 행의 `premium_expired_at` 을 임의 설정하면
+**프리미엄(그룹 무제한)을 무료로 얻는다** (로컬 실증 완료 — security-backlog 8번).
+
+`is_admin` 과 같은 원인이고 처방도 같다. 지금까지 못 막은 이유는 어드민 화면(`OperationsTab`)이
+**클라이언트에서 직접** 이 컬럼에 쓰기 때문 — 잠그면 어드민 기능이 먼저 깨진다.
+그래서 **최소 서버 경로를 먼저 만들고 → 컬럼 권한을 회수**한다 (backlog 의 기존 결정).
+
+## 설계
+
+### 1) 서버 경로 — `POST /api/admin/premium`
+
+- 호출자 검사: `anon`·`service_role` → 401. **호출자의 `profiles.is_admin` 을 DB 에서 읽어** false 면 403
+  (함수는 service role 클라이언트라 **함수 코드가 권한 검사의 전부** — CLAUDE.md 체크리스트 준수)
+- body: `{ userId, premiumExpiredAt }` — 대상 uuid + ISO 일시 **또는 null(해제)**. 그 외 400
+- service role 로 대상 행의 `premium_expired_at` 만 갱신
+
+어드민 전용 라우터를 새로 만든다. 폐기했던 PR C(어드민 대시보드 백엔드 전체)와 달리
+**이 한 가지 쓰기만** 담는다 — 대시보드 읽기는 지금대로 클라이언트 조회를 유지한다.
+
+### 2) 컬럼 권한 회수 — 마이그레이션
+
+#39 와 같은 패턴: `revoke update` 후 `premium_expired_at` 만 뺀 목록으로 재부여.
+
+- `deleted_at`(soft delete, #56 추가)은 원래 목록에 없었고 클라이언트가 쓸 일이 없다 — **이번에도 넣지 않는다**
+- 컬럼 추가 시 목록 갱신 필요하다는 기존 주석 유지
+
+### 3) web 전환 — `OperationsTab`
+
+- `updateProfile(id, { premium_expired_at })` → `apis/admin.ts` 의 새 함수 `setPremiumExpiry()` (엔드포인트 호출)
+- **결과 확인 추가** — 지금은 실패해도 "설정했어요" toast 가 뜬다
+- `updateProfilesParams` 타입에서 `premium_expired_at` 제거 — 재사용을 타입으로 차단.
+  다른 `updateProfile` 호출자 전수 확인 결과 premium 을 넘기는 곳은 OperationsTab 뿐이다
+
+읽기 경로(`AuthProvider` 의 플랜 판정)는 그대로 — 권한 회수는 쓰기만 막는다.
+
+## 파일 매니페스트
+
+### PrayU-Api (선행 PR)
+
+| 파일 | 내용 |
+|---|---|
+| `supabase/migrations/<ts>_revoke_premium_update.sql` (신규) | revoke + `premium_expired_at` 제외 재부여 |
+| `supabase/functions/api/admin/adminRouter.ts` (신규) | `use(authMiddleware)` + `post("/premium")` |
+| `supabase/functions/api/admin/adminController.ts` (신규) | 401/403/400 검사, 입력 검증 |
+| `supabase/functions/api/admin/adminRepository.ts` (신규) | `isAdmin(userId)` · `setPremiumExpiry(userId, at)` |
+| `supabase/functions/api/index.ts` (수정) | `/admin` 라우트 등록 |
+| `CLAUDE.md` (수정) | 전수 대장의 컬럼 권한 행에 premium 반영, "예정" 문단 제거 |
+
+### PrayU-web (짝 PR)
+
+| 파일 | 내용 |
+|---|---|
+| `src/apis/admin.ts` (수정) | `setPremiumExpiry(userId, premiumExpiredAt)` — 세션 토큰으로 엔드포인트 호출 |
+| `src/apis/profiles.ts` (수정) | `updateProfilesParams` 에서 `premium_expired_at` 제거 |
+| `src/pages/AdminPage/tabs/OperationsTab.tsx` (수정) | 새 함수 호출 + 실패 toast |
+
+타입 재생성 불필요 — 권한 변경은 스키마 모양을 바꾸지 않는다.
+
+**merge 순서: Api 먼저 → web.** 그 사이 staging 어드민의 프리미엄 설정 버튼만 잠깐 막힌다
+(관리자 전용 화면이라 영향 범위가 사람 한 명이다).
+
+## 검증 (로컬)
+
+- `db reset` 재생 무오류
+- **비어드민이 PostgREST 로 자기 premium 직접 UPDATE → 거부** (핵심 — 구멍이 실제로 닫혔는가)
+- 비어드민의 기존 프로필 수정(이름 등) → 정상 (재부여 목록 누락 확인)
+- 엔드포인트: 비어드민 403 · anon 401 · 어드민 설정 200 · null 해제 200 · 잘못된 날짜 400
+- 어드민 UI 에서 설정/해제 → 목록 갱신 + 대상 계정 플랜 판정 반영
+
+## 한계
+
+- **그룹 수 한도 강제 자체가 클라이언트에 있다** (`GroupMenuBtn` 의 `VITE_MAX_GROUP_COUNT` 비교).
+  이번 작업은 "프리미엄 위조"를 막을 뿐, 한도 검사를 우회한 직접 INSERT 는 **RLS 전면 정비(1번)** 사안이다
+- `VITE_PREMIUM_PLAN_USERLIST` Vercel 환경변수는 코드에서 더 이상 안 읽는다 — 정리 후보 (사람 조작, backlog)

--- a/supabase/functions/_types/database.ts
+++ b/supabase/functions/_types/database.ts
@@ -528,7 +528,7 @@ export type Database = {
           avatar_url: string | null
           blocking_users: string[]
           created_at: string
-          fcm_token: string
+          deleted_at: string | null
           full_name: string | null
           id: string
           is_admin: boolean
@@ -546,7 +546,7 @@ export type Database = {
           avatar_url?: string | null
           blocking_users?: string[]
           created_at?: string
-          fcm_token?: string
+          deleted_at?: string | null
           full_name?: string | null
           id: string
           is_admin?: boolean
@@ -564,7 +564,7 @@ export type Database = {
           avatar_url?: string | null
           blocking_users?: string[]
           created_at?: string
-          fcm_token?: string
+          deleted_at?: string | null
           full_name?: string | null
           id?: string
           is_admin?: boolean

--- a/supabase/functions/api/admin/adminController.ts
+++ b/supabase/functions/api/admin/adminController.ts
@@ -1,0 +1,73 @@
+import { Context } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { corsHeaders } from "../../_shared/cors.ts";
+import { AdminRepository } from "./adminRepository.ts";
+
+const json = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class AdminController {
+  private adminRepository: AdminRepository;
+
+  constructor() {
+    this.adminRepository = new AdminRepository();
+  }
+
+  /**
+   * 대상 사용자의 프리미엄 만료일 설정/해제.
+   *
+   * 클라이언트의 profiles.premium_expired_at 직접 UPDATE 는 컬럼 권한으로 막혀 있다
+   * (revoke_premium_update 마이그레이션) — 이 경로가 유일한 쓰기 지점이다.
+   * 함수는 service role 클라이언트라 **여기의 is_admin 검사가 권한의 전부**다.
+   */
+  async setPremiumExpiryV1(c: Context) {
+    const callerId = c.get("userId");
+    // 로그인 사용자만 — 인프라 호출자(service_role)가 쓸 일이 없다
+    if (!callerId || callerId === "anon" || callerId === "service_role") {
+      return json({ data: null, error: "Unauthorized" }, 401);
+    }
+    if (!(await this.adminRepository.isAdmin(callerId))) {
+      return json({ data: null, error: "Forbidden" }, 403);
+    }
+
+    let body: { userId?: string; premiumExpiredAt?: string | null };
+    try {
+      body = await c.req.json();
+    } catch {
+      return json({ data: null, error: "Invalid body" }, 400);
+    }
+
+    const { userId, premiumExpiredAt } = body;
+    if (!userId || !UUID_RE.test(userId)) {
+      return json({ data: null, error: "userId must be a uuid" }, 400);
+    }
+    // null 은 해제. 문자열이면 파싱 가능한 일시여야 한다
+    if (
+      premiumExpiredAt !== null &&
+      (typeof premiumExpiredAt !== "string" ||
+        Number.isNaN(Date.parse(premiumExpiredAt)))
+    ) {
+      return json(
+        { data: null, error: "premiumExpiredAt must be an ISO datetime or null" },
+        400,
+      );
+    }
+
+    try {
+      const found = await this.adminRepository.setPremiumExpiry(
+        userId,
+        premiumExpiredAt,
+      );
+      if (!found) return json({ data: null, error: "User not found" }, 404);
+      return json({ data: { userId, premiumExpiredAt }, error: null }, 200);
+    } catch (error) {
+      console.error("Failed to set premium expiry:", error);
+      return json({ data: null, error: "Failed to set premium expiry" }, 500);
+    }
+  }
+}

--- a/supabase/functions/api/admin/adminRepository.ts
+++ b/supabase/functions/api/admin/adminRepository.ts
@@ -1,0 +1,33 @@
+import { supabase } from "../../client.ts";
+
+export class AdminRepository {
+  /** 호출자가 관리자인가. 행이 없으면 false — 없는 계정에 권한을 주지 않는다 */
+  async isAdmin(userId: string): Promise<boolean> {
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("is_admin")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (error) throw new Error(`isAdmin: ${error.message}`);
+    return data?.is_admin === true;
+  }
+
+  /**
+   * 대상의 프리미엄 만료일을 설정한다 (null = 해제).
+   * 갱신된 행을 돌려받아 **대상 존재 여부를 구분**한다 — 없는 uuid 면 빈 배열이다.
+   */
+  async setPremiumExpiry(
+    userId: string,
+    premiumExpiredAt: string | null,
+  ): Promise<boolean> {
+    const { data, error } = await supabase
+      .from("profiles")
+      .update({ premium_expired_at: premiumExpiredAt })
+      .eq("id", userId)
+      .select("id");
+
+    if (error) throw new Error(`setPremiumExpiry: ${error.message}`);
+    return (data?.length ?? 0) > 0;
+  }
+}

--- a/supabase/functions/api/admin/adminRouter.ts
+++ b/supabase/functions/api/admin/adminRouter.ts
@@ -1,0 +1,11 @@
+import { Hono } from "https://deno.land/x/hono@v4.3.11/mod.ts";
+import { AdminController } from "./adminController.ts";
+import { authMiddleware } from "../../_shared/authMiddleware.ts";
+
+const adminRouter = new Hono();
+const adminController = new AdminController();
+
+adminRouter.use("*", authMiddleware);
+adminRouter.post("/premium", (c) => adminController.setPremiumExpiryV1(c));
+
+export default adminRouter;

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -2,12 +2,14 @@ import { Hono } from "https://deno.land/x/hono@v4.3.11/mod.ts";
 import userRouter from "./users/userRouter.ts";
 import churchRouter from "./churches/churchRouter.ts";
 import uploadRouter from "./upload/uploadRouter.ts";
+import adminRouter from "./admin/adminRouter.ts";
 
 const app = new Hono();
 
 app.basePath("/api")
   .route("/users", userRouter)
   .route("/churches", churchRouter)
-  .route("/upload-url", uploadRouter);
+  .route("/upload-url", uploadRouter)
+  .route("/admin", adminRouter);
 
 Deno.serve(app.fetch);

--- a/supabase/functions/api/users/userRepository.ts
+++ b/supabase/functions/api/users/userRepository.ts
@@ -74,7 +74,7 @@ export class UserRepository {
    * 개인정보 **파기**는 이 단계의 책임이 아니다 — 나중에 돌릴 배치 하드 삭제가 진다
    * (docs/archive/account-deletion-plan.md "한계" 절).
    *
-   * 참고: `fcm_token`·`push_notification` 은 함수 어디서도 읽지 않는다(푸시는 OneSignal 경로).
+   * 참고: `push_notification` 은 함수 어디서도 읽지 않는다(푸시는 OneSignal 경로).
    * 비워도 동작이 달라지지 않아 남겨 둔다.
    */
   async markProfileDeleted(userId: string, deletedAt: string) {

--- a/supabase/migrations/20260731111601_revoke_premium_update.sql
+++ b/supabase/migrations/20260731111601_revoke_premium_update.sql
@@ -1,0 +1,16 @@
+-- premium_expired_at 자기부여 차단 (docs/plans/premium-guard.md · security-backlog 8번)
+--
+-- #39 에서 is_admin 을 컬럼 권한으로 막을 때 재부여 목록에 premium_expired_at 이 남아,
+-- 로그인한 사용자가 자기 행에 임의 만료일을 넣어 프리미엄(그룹 무제한)을 공짜로 얻을 수
+-- 있었다. 같은 패턴으로 목록에서 뺀다 — 어드민 쓰기는 서버 경로(POST /api/admin/premium)로
+-- 옮겨졌으므로 이제 클라이언트가 이 컬럼을 쓸 정당한 경로는 없다.
+--
+-- 컬럼 추가 시 이 목록에도 넣어야 한다 — 누락되면 해당 컬럼 수정이 즉시 실패해 드러난다.
+-- deleted_at(#56)은 의도적으로 없다: 탈퇴 표시는 서버(service role)만 쓴다.
+
+revoke update on table "public"."profiles" from anon, authenticated;
+grant update (
+    updated_at, username, full_name, avatar_url, website,
+    kakao_id, kakao_notification, terms_agreed_at, blocking_users,
+    push_notification, fcm_token, created_at, app_settings
+) on table "public"."profiles" to authenticated;

--- a/supabase/migrations/20260731111601_revoke_premium_update.sql
+++ b/supabase/migrations/20260731111601_revoke_premium_update.sql
@@ -8,9 +8,16 @@
 -- 컬럼 추가 시 이 목록에도 넣어야 한다 — 누락되면 해당 컬럼 수정이 즉시 실패해 드러난다.
 -- deleted_at(#56)은 의도적으로 없다: 탈퇴 표시는 서버(service role)만 쓴다.
 
+-- 겸사겸사 fcm_token 을 제거한다. Firebase 푸시는 OneSignal 로 대체됐고, 읽는 곳이
+-- 전수 조사에서 하나도 없었다 — edge function·DB 함수/트리거/뷰·web·Flutter 앱 모두 0건.
+-- (레거시 fcm_notification_webhook 트리거는 drop_legacy_fcm_webhook 에서 이미 제거)
+-- 가입 트리거 handle_new_user() 는 id·full_name·avatar_url 만 INSERT 하므로 영향 없다.
+-- 같은 grant 목록을 다시 쓰는 마이그레이션이라 여기서 함께 처리하는 편이 안전하다.
+alter table "public"."profiles" drop column if exists "fcm_token";
+
 revoke update on table "public"."profiles" from anon, authenticated;
 grant update (
     updated_at, username, full_name, avatar_url, website,
     kakao_id, kakao_notification, terms_agreed_at, blocking_users,
-    push_notification, fcm_token, created_at, app_settings
+    push_notification, created_at, app_settings
 ) on table "public"."profiles" to authenticated;


### PR DESCRIPTION
계획: [docs/plans/premium-guard.md](docs/plans/premium-guard.md) · security-backlog **8번** · v1.0.0 포함분
web 짝 PR 이 뒤따른다 — **merge 는 Api 먼저**

## 구멍

[#39](https://github.com/TeamVisioneer/PrayU-Api/pull/39) 에서 `is_admin` 을 컬럼 권한으로 막을 때
**재부여 목록에 `premium_expired_at` 이 남아 있었다.**

```sql
grant update ( ..., app_settings, premium_expired_at ) on profiles to authenticated;
```

로그인한 사용자가 PostgREST 로 자기 행에 만료일을 넣으면 **프리미엄(그룹 무제한)을 공짜로** 얻는다.

## 왜 지금까지 못 막았나 → 순서로 푼다

어드민 화면(`OperationsTab`)이 이 컬럼에 **클라이언트에서 직접** 쓴다. 잠그면 어드민이 먼저 깨진다.
그래서 **최소 서버 경로를 먼저 만들고 → 권한을 회수**한다.

## 무엇

| 파일 | 내용 |
|---|---|
| `migrations/…_revoke_premium_update.sql` | revoke 후 `premium_expired_at` 뺀 목록으로 재부여 |
| `functions/api/admin/adminController.ts` | 401/403/400/404, 입력 검증 |
| `functions/api/admin/adminRepository.ts` | `isAdmin()` · `setPremiumExpiry()` |
| `functions/api/admin/adminRouter.ts` · `index.ts` | `POST /api/admin/premium` |
| `CLAUDE.md` | DB 로직 전수 대장 갱신 (`is_admin`·`premium_expired_at` 제외로), "예정" 문단 제거 |

**폐기했던 PR C 와 다르다** — 어드민 백엔드 전체가 아니라 **이 쓰기 하나만** 담는다.
대시보드 읽기는 지금대로 클라이언트 조회를 유지한다.

`deleted_at`([#56](https://github.com/TeamVisioneer/PrayU-Api/pull/56))도 재부여 목록에 **의도적으로 넣지 않았다** — 탈퇴 표시는 service role 만 쓴다.

## 검증 — 공격을 그대로 재현했다

| 시나리오 | 결과 |
|---|---|
| **비어드민이 자기 `premium_expired_at` 직접 UPDATE** | **403 permission denied** ← 구멍이 닫혔다 |
| 비어드민이 자기 `is_admin` 직접 UPDATE | 403 (회귀 없음) |
| 비어드민이 자기 이름 수정 | **204** (재부여 목록 누락 없음) |
| 엔드포인트 — 비로그인 / 비어드민 | 401 / **403** |
| 어드민 설정 / 해제(null) | 200 / 200 (DB 반영 확인) |
| 잘못된 날짜 / uuid 아님 / 없는 대상 | 400 / 400 / 404 |
| `supabase db reset` | 재생 무오류 |

권한 목록도 직접 조회해 확인했다 — `authenticated` 의 UPDATE 컬럼 13개에 `premium_expired_at`·`is_admin`·`deleted_at` 없음.

## 알아둘 한계

**그룹 수 한도 강제 자체가 클라이언트에 있다**(`VITE_MAX_GROUP_COUNT` 비교). 이번 작업은 "프리미엄 위조"를 막는 것이고,
한도 검사를 우회한 직접 INSERT 는 **RLS 전면 정비(1번)** 사안이다.

## merge 후

web 짝 PR 전까지 **staging 어드민의 프리미엄 설정 버튼이 잠깐 막힌다** (관리자 전용 화면이라 영향은 사람 한 명).

🤖 Generated with [Claude Code](https://claude.com/claude-code)