### PR TITLE
feat: upload-url KINDS 에 avatar 추가 — 프로필 사진 변경 선행분

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -130,6 +130,13 @@ staging 에 넣고 prod 에 빠뜨리면 **release 후 500 이 날 때** 알게 
 - [ ] 배포 워크플로 수정이라 **사람 확인 후 진행**. 시크릿 보관처가 하나 늘어나는 대가(로테이션 시 GitHub 도 갱신)를 감수할지 판단 필요
 - 판단 보류 근거: 시크릿이 4~6개 수준이면 사람이 관리 가능한 규모다. 개수가 늘거나 환경이 추가되면 그때 한다
 
+### 프로필 사진 변경 (짝 작업 — 주도: web)
+
+계획: [PrayU-web/docs/plans/profile-photo.md](../../PrayU-web/docs/plans/profile-photo.md)
+
+- [x] ~~Api — `upload-url` KINDS 에 `avatar` 추가~~ (이 레포의 유일한 단계. merge 는 **Api 먼저 → web**)
+- [ ] 후속: 아바타 재변경 시 옛 R2 파일이 orphan 으로 남는다 — 삭제 훅/정리 배치 미구현 (용량 문제가 되면 착수)
+
 ### 기타
 - [ ] QT 응답 토큰을 `llm_usage_log`에 기록 (현재 호출 수만 차감)
 - [ ] `deno.lock` 커밋 여부 결정

--- a/supabase/functions/api/upload/uploadController.ts
+++ b/supabase/functions/api/upload/uploadController.ts
@@ -3,7 +3,7 @@ import { corsHeaders } from "../../_shared/cors.ts";
 import { presignPutUrl } from "./uploadService.ts";
 
 /** 올릴 수 있는 용도. 경로를 클라이언트가 정하지 못하게 이 목록으로 제한한다 */
-const KINDS = ["bible_card", "thanks_card", "notice"] as const;
+const KINDS = ["bible_card", "thanks_card", "notice", "avatar"] as const;
 type Kind = (typeof KINDS)[number];
 
 /** 허용 타입 → 확장자. 목록에 없으면 거부한다 */


### PR DESCRIPTION
web 프로필 사진 변경 기능의 선행 서버 단계. 계획: PrayU-web `docs/plans/profile-photo.md` (짝 PR 본문에 링크 예정)

## 변경

- `uploadController.ts` `KINDS` 화이트리스트에 `"avatar"` 추가 — key 는 서버가 `avatar/{uuid}.{ext}` 로 생성 (기존 규칙 그대로)
- 검증은 기존 그대로 충분: contentType 화이트리스트(jpeg/png/webp/gif) · 로그인 사용자 전용(anon/service_role 401) · 경로는 클라이언트가 못 정함
- backlog: 아바타 재변경 시 옛 R2 파일 orphan 후속 등재

## merge 순서

**이 PR 먼저 merge·staging 배포 → web PR** — 순서가 뒤집히면 web 이 `kind: "avatar"` 로 400 을 받는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)